### PR TITLE
Added 'out' keyword awareness for Interactive

### DIFF
--- a/hyperspy/interactive.py
+++ b/hyperspy/interactive.py
@@ -4,7 +4,11 @@ class Interactive:
         self.args = args
         self.kwargs = kwargs
         self.sig = obj
-        self.out = self.f(*args, **kwargs)
+        if kwargs.has_key('out'):
+            self.f(*args, **kwargs)
+            self.out = kwargs.pop('out')
+        else:
+            self.out = self.f(*args, **kwargs)
         event.connect(self.update)
 
     def update(self):


### PR DESCRIPTION
Added possiblity to use interactive with existing signal by it picking
up on the 'out' keyword being passed to the function. No such
functionality for positional args, naturally.
