### PR TITLE
Removed redundant 'obj', and allow and ignore args to update

### DIFF
--- a/hyperspy/interactive.py
+++ b/hyperspy/interactive.py
@@ -1,17 +1,20 @@
 class Interactive:
-    def __init__(self, obj, f, event, *args, **kwargs):
+    def __init__(self, f, event, *args, **kwargs):
         self.f = f
         self.args = args
         self.kwargs = kwargs
-        self.sig = obj
-        self.out = self.f(*args, **kwargs)
+        if kwargs.has_key('out'):
+            self.f(*args, **kwargs)
+            self.out = kwargs.pop('out')
+        else:
+            self.out = self.f(*args, **kwargs)
         event.connect(self.update)
 
     def update(self, *args, **kwargs):
         self.f(out=self.out, *self.args, **self.kwargs)
 
 
-def interactive(obj, f, event, *args, **kwargs):
+def interactive(f, event, *args, **kwargs):
     """Update operation result when a given event is triggered.
 
     Parameters
@@ -30,5 +33,5 @@ def interactive(obj, f, event, *args, **kwargs):
 
     """
 
-    cls = Interactive(obj, f, event, *args, **kwargs)
+    cls = Interactive(f, event, *args, **kwargs)
     return cls.out

--- a/hyperspy/interactive.py
+++ b/hyperspy/interactive.py
@@ -7,7 +7,7 @@ class Interactive:
         self.out = self.f(*args, **kwargs)
         event.connect(self.update)
 
-    def update(self):
+    def update(self, *args, **kwargs):
         self.f(out=self.out, *self.args, **self.kwargs)
 
 


### PR DESCRIPTION
The argument `obj` and `Interactive.sig` was never used.

For `update`, it is nice for it to take args, so that it can be connected to events that pass args without errors. However, preferably Events should help out with these issues. E.g. qt's signals can be connected using `qtsignal[bool].connect(f)` to connect a function that expects a bool arg, while `qtsignal.connect(f)` is used for argument-free functions.
