### PR TITLE
New events signatures

### DIFF
--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -1,4 +1,4 @@
-import sys
+import sys, copy
 
 class EventSuppressionContext(object):
     """
@@ -55,7 +55,17 @@ class Event(object):
 
     def __init__(self):
         self.connected = set()
-        self.suppress = False
+        self._suppress = [False]    # Keep in list so shallow copies share
+        self._nargs = 0
+        self._signatures = {tuple([]): self}
+    
+    @property
+    def suppress(self):
+        return self._suppress[0]
+    
+    @suppress.setter
+    def suppress(self, value):
+        self._suppress[0] = value
 
     def connect(self, function):
         if not callable(function):
@@ -64,13 +74,34 @@ class Event(object):
 
     def disconnect(self, function):
         self.connected.remove(function)
+    
+    def _do_trigger(self, *args):
+        if len(args) < self._nargs:
+            raise ValueError(("Tried to call %s which require %d args " + \
+                "with only %d.") % (str(self.connected), self._nargs, len(args)))
+        for f in self.connected:
+            f(*args[0:self._nargs])
 
-    def trigger(self, *args, **kwargs):
+    def trigger(self, *args):
         if not self.suppress:
-            for f in self.connected:
-                f(*args, **kwargs)
+            self._do_trigger(*args)
+            for s in self._signatures.values():
+                s._do_trigger(*args)
 
     def __deepcopy__(self, memo):
         dc = type(self)()
         memo[id(self)] = dc
         return dc
+    
+    def __getitem__(self, nargs):
+        if nargs is None:
+            nargs = 0
+        if nargs in self._signatures:
+            return self._signatures[nargs]
+        else:
+            r = copy.copy(self)
+            r.connected = set()
+            r._nargs = nargs
+            self._signatures[nargs] = r
+            return r
+            


### PR DESCRIPTION
Added ability to specify number of args a connected function should be
called with, by using `__getitem__` when connecting. Example:

``` python
e = Event()
e.connect(lambda: <do something>)  # nargs = 0
e[1].connect(lambda x: <do something>) # nargs = 1
e[2].connect(lambda x,y: <do something>) # nargs = 2

e.trigger(31, 55)
# should call first lambda with 0 args, second with x=31, and
# third with x=31 and y=55.

# This will cause a ValueError since it cannot correctly call the third
# lambda:
e.trigger(31)
```
