### PR TITLE
Automatic traits Events wrapper

### DIFF
--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -198,6 +198,13 @@ class Event(object):
             if function in c:
                 c.remove(function)
 
+    @staticmethod
+    def _trigger_nargs(f, args, nargs):
+        """
+        Basic trigger resolution.
+        """
+        return f(*args[0:nargs])
+
     def trigger(self, *args, **kwargs):
         if not self._suppress:
             # Loop on copy to deal with callbacks which change connections
@@ -211,7 +218,7 @@ class Event(object):
                             ("Tried to call %s which require %d args " +
                              "with only %d.") % (str(c), nargs, len(args)))
                     for f in c.copy():
-                        f(*args[0:nargs])
+                        self._trigger_nargs(f, args, nargs)
 
     def __deepcopy__(self, memo):
         dc = type(self)()

--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -263,29 +263,16 @@ def _wrap_trait(collection, obj, name):
     obj.on_trait_change(e.trigger, name)
 
 
-def _init_wrap(self, *args, **kwargs):
-    if self._old_init is not None:
-        self._old_init(*args, **kwargs)
-
-    # Setup events container if missing
-    if not hasattr(self, 'events'):
-        self.events = Events()
-
-    # Wrap traits
-    if isinstance(self, HasTraits):
-        for t in self.traits().iterkeys():
-            if t in traits_filter:
-                continue
-            _wrap_trait(self.events, self, t)
-
-
-class MetaHasEventsTraits(MetaHasTraits):
-
-    def __new__(cls, name, bases, attrs):
-        attrs['_old_init'] = attrs.pop('__init__', None)
-        attrs['__init__'] = _init_wrap
-        return super(MetaHasEventsTraits, cls).__new__(cls, name, bases, attrs)
-
-
 class HasEventsTraits(HasTraits):
-    __metaclass__ = MetaHasEventsTraits
+    def __init__(self, *args, **kwargs):
+        super(HasEventsTraits, self).__init__(*args, **kwargs)
+        # Setup events container if missing
+        if not hasattr(self, 'events'):
+            self.events = Events()
+
+        # Wrap traits
+        if isinstance(self, HasTraits):
+            for t in self.traits().iterkeys():
+                if t in traits_filter:
+                    continue
+                _wrap_trait(self.events, self, t)

--- a/hyperspy/tests/test_events.py
+++ b/hyperspy/tests/test_events.py
@@ -284,6 +284,7 @@ class TestTraitsEvents(EventsBase):
             c = t.Instance(dummy_simple)
 
             def __init__(self):
+                super(dummy, self).__init__()
                 self.c = dummy_simple()
 
         self.obj = dummy_simple()


### PR DESCRIPTION
By replacing `traits.api.HasTraits` with `hyperspy.Events.HasEventsTraits`, `traits` will work as previously, but an `Event` will be created for the change notifier of each trait. So if the class has traits A, B and C, this will automatically create `events.A_changed`, `events.B_changed` and `events.C_changed`. It also retains the callback argument signatures of traits (new; name, new; obj, name, new; obj, name, old, new).
