### PR TITLE
Tweak date time ser

### DIFF
--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -467,6 +467,9 @@ def ser_reader(filename, objects=None, *args, **kwds):
     record_by = guess_record_by(header['DataTypeID'])
     ndim = int(header['NumberDimensions'])
     date, time = None, None
+    if objects is not None:
+        objects_dict = convert_xml_to_dict(objects[0])
+        date, time = _get_date_time(objects_dict.ObjectInfo.AcquireDate)
     if "PositionY" in data.dtype.names and len(data['PositionY']) > 1 and \
             (data['PositionY'][0] == data['PositionY'][1]):
         # The spatial dimensions are stored in F order i.e. X, Y, ...
@@ -522,9 +525,7 @@ def ser_reader(filename, objects=None, *args, **kwds):
 
     elif record_by == 'image':
         if objects is not None:
-            objects_dict = convert_xml_to_dict(objects[0])
             units = _guess_units_from_mode(objects_dict, header)
-            date, time = _get_date_time(objects_dict.ObjectInfo.AcquireDate)
         else:
             units = "meters"
         # Y axis

--- a/hyperspy/tests/io/test_fei.py
+++ b/hyperspy/tests/io/test_fei.py
@@ -42,12 +42,6 @@ class TestFEIReader():
         # TIA new format
         fname1 = os.path.join(self.dirpathnew, '128x128_TEM_acquire-sum1.emi')
         load(fname1)
-        # TIA new format 1Go file
-#        fname2= os.path.join('/mnt/data/test/64bits', 'CCD Preview-250-beam_damaged.emi')
-#        load(fname2)
-        # TIA new format 4Go file
-#        fname2= os.path.join('/mnt/data/test/64bits', '11.22.31 CCD Preview-250-bean_damaged-bin2-0.2s.emi')
-#        load(fname2)
 
     def test_load_image_content(self):
         # TEM image of the beam stop
@@ -93,7 +87,8 @@ class TestFEIReader():
             s0[0].metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         nt.assert_almost_equal(s0[0].axes_manager[0].scale, 3.68864, places=5)
         nt.assert_equal(s0[0].axes_manager[0].units, 'nm')
-        nt.assert_equal(s0[0].axes_manager[0].name, 'y') # Should this name be y?
+        nt.assert_equal(s0[0].axes_manager[0].name,
+                        'y')  # Should this name be y?
         nt.assert_almost_equal(s0[0].axes_manager[1].scale, 5.0, places=5)
         nt.assert_equal(s0[0].axes_manager[1].units, 'eV')
         nt.assert_equal(s0[0].axes_manager[1].name, 'Energy')
@@ -104,7 +99,8 @@ class TestFEIReader():
             s0[1].metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         nt.assert_almost_equal(s0[1].axes_manager[0].scale, 3.68864, places=5)
         nt.assert_equal(s0[1].axes_manager[0].units, 'nm')
-        nt.assert_equal(s0[1].axes_manager[0].name, 'y') # Should this name be y?
+        nt.assert_equal(s0[1].axes_manager[0].name,
+                        'y')  # Should this name be y?
         nt.assert_almost_equal(s0[1].axes_manager[1].scale, 0.17435, places=5)
         nt.assert_equal(s0[1].axes_manager[1].units, '1/nm')
         nt.assert_equal(s0[1].axes_manager[1].name, 'x')
@@ -157,11 +153,18 @@ class TestFEIReader():
         nt.assert_equal(
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         # single spectrum should be imported as 1D data, not 2D
-        nt.assert_almost_equal(
-            s0.axes_manager[0].scale, 1000000000.0, places=5)
-        nt.assert_equal(s0.axes_manager[0].units, 'nm')
+        # TODO: the following calibration is wrong because it parse the
+        # 'Dim-1_CalibrationDelta' from the ser header, which is not correct in
+        # case of point spectra. However, the position seems to be saved in
+        # 'PositionX' and 'PositionY' arrays of the ser header, so it should
+        # be possible to workaround using the position arrays.
+#        nt.assert_almost_equal(
+#            s0.axes_manager[0].scale, 1.0, places=5)
+#        nt.assert_equal(s0.axes_manager[0].units, '')
+#        nt.assert_is(s0.axes_manager[0].name, 'Position index')
         nt.assert_almost_equal(s0.axes_manager[1].scale, 0.2, places=5)
         nt.assert_equal(s0.axes_manager[1].units, 'eV')
+        nt.assert_equal(s0.axes_manager[1].name, 'Energy')
 
         fname1 = os.path.join(
             self.dirpathold, '16x16-2_point-spectra-2x1024.emi')
@@ -170,11 +173,9 @@ class TestFEIReader():
         nt.assert_equal(s1.axes_manager.signal_dimension, 1)
         nt.assert_equal(
             s1.metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
-        nt.assert_almost_equal(
-            s0.axes_manager[0].scale, 1000000000.0, places=5)
-        nt.assert_equal(s0.axes_manager[0].units, 'nm')
         nt.assert_almost_equal(s0.axes_manager[1].scale, 0.2, places=5)
         nt.assert_equal(s0.axes_manager[1].units, 'eV')
+        nt.assert_equal(s0.axes_manager[1].name, 'Energy')
 
     def test_load_spectrum_line_scan(self):
         fname0 = os.path.join(
@@ -186,8 +187,10 @@ class TestFEIReader():
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         nt.assert_almost_equal(s0.axes_manager[0].scale, 0.12303, places=5)
         nt.assert_equal(s0.axes_manager[0].units, 'nm')
+        nt.assert_equal(s0.axes_manager[0].name, 'y')
         nt.assert_almost_equal(s0.axes_manager[1].scale, 0.2, places=5)
         nt.assert_equal(s0.axes_manager[1].units, 'eV')
+        nt.assert_equal(s0.axes_manager[1].name, 'Energy')
 
         fname1 = os.path.join(
             self.dirpathold, '16x16-line_profile_diagonal_10x1024.emi')
@@ -211,10 +214,13 @@ class TestFEIReader():
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         nt.assert_almost_equal(s0.axes_manager[0].scale, 0.120539, places=5)
         nt.assert_equal(s0.axes_manager[0].units, 'nm')
+        nt.assert_equal(s0.axes_manager[0].name, 'x')
         nt.assert_almost_equal(s0.axes_manager[1].scale, -0.120539, places=5)
         nt.assert_equal(s0.axes_manager[1].units, 'nm')
+        nt.assert_equal(s0.axes_manager[1].name, 'y')
         nt.assert_almost_equal(s0.axes_manager[2].scale, 0.2, places=5)
         nt.assert_equal(s0.axes_manager[2].units, 'eV')
+        nt.assert_equal(s0.axes_manager[2].name, 'Energy')
 
     def test_load_spectrum_area_scan_not_square(self):
         fname0 = os.path.join(
@@ -263,10 +269,14 @@ class TestFEIReader():
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode, 'TEM')
         nt.assert_almost_equal(s0.axes_manager[0].scale, 1.0, places=5)
         nt.assert_is(s0.axes_manager[0].units, t.Undefined)
+        nt.assert_equal(s0.axes_manager[0].scale, 1.0)
+        nt.assert_is(s0.axes_manager[0].name, t.Undefined)
         nt.assert_almost_equal(s0.axes_manager[1].scale, 6.281833, places=5)
         nt.assert_equal(s0.axes_manager[1].units, 'nm')
+        nt.assert_equal(s0.axes_manager[1].name, 'x')
         nt.assert_almost_equal(s0.axes_manager[2].scale, 6.281833, places=5)
         nt.assert_equal(s0.axes_manager[2].units, 'nm')
+        nt.assert_equal(s0.axes_manager[2].name, 'y')
 
         fname2 = os.path.join(
             self.dirpathnew, '128x128x5-diffraction_preview.emi')
@@ -299,8 +309,10 @@ class TestFEIReader():
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode, 'TEM')
         nt.assert_almost_equal(s0.axes_manager[0].scale, 6.281833, places=5)
         nt.assert_equal(s0.axes_manager[0].units, 'nm')
+        nt.assert_equal(s0.axes_manager[0].name, 'x')
         nt.assert_almost_equal(s0.axes_manager[1].scale, 6.281833, places=5)
         nt.assert_equal(s0.axes_manager[1].units, 'nm')
+        nt.assert_equal(s0.axes_manager[1].name, 'y')
 
         fname1 = os.path.join(self.dirpathold, '16x16_STEM_BF_DF_acquire.emi')
         s1 = load(fname1)
@@ -312,9 +324,11 @@ class TestFEIReader():
             nt.assert_almost_equal(
                 s.axes_manager[0].scale, 21.510044, places=5)
             nt.assert_equal(s.axes_manager[0].units, 'nm')
+            nt.assert_equal(s.axes_manager[0].name, 'x')
             nt.assert_almost_equal(
                 s.axes_manager[1].scale, 21.510044, places=5)
             nt.assert_equal(s.axes_manager[1].units, 'nm')
+            nt.assert_equal(s.axes_manager[1].name, 'y')
 
     def test_read_STEM_TEM_mode(self):
         # TEM image
@@ -385,6 +399,12 @@ class TestFEIReader():
         nt.assert_equal(s.metadata.General.date, "2016-02-21")
         nt.assert_equal(s.metadata.General.time, "17:50:18")
         nt.assert_equal(s.metadata.General.authors, "ERIC")
+
+        fname1 = os.path.join(self.dirpathold,
+                              '16x16-line_profile_horizontal_10x1024.emi')
+        s = load(fname1)
+        nt.assert_false(s.metadata.has_item('General.date'))
+        nt.assert_false(s.metadata.has_item('General.time'))
 
     def test_metadata_TEM(self):
         fname0 = os.path.join(self.dirpathold, '64x64_TEM_images_acquire.emi')

--- a/hyperspy/tests/io/test_fei.py
+++ b/hyperspy/tests/io/test_fei.py
@@ -77,8 +77,10 @@ class TestFEIReader():
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode, 'TEM')
         nt.assert_almost_equal(s0.axes_manager[0].scale, 0.10157, places=5)
         nt.assert_equal(s0.axes_manager[0].units, '1/nm')
+        nt.assert_equal(s0.axes_manager[0].name, 'x')
         nt.assert_almost_equal(s0.axes_manager[1].scale, 0.10157, places=5)
         nt.assert_equal(s0.axes_manager[1].units, '1/nm')
+        nt.assert_equal(s0.axes_manager[1].name, 'y')
 
     def test_load_diffraction_line_scan(self):
         fname0 = os.path.join(
@@ -91,8 +93,10 @@ class TestFEIReader():
             s0[0].metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         nt.assert_almost_equal(s0[0].axes_manager[0].scale, 3.68864, places=5)
         nt.assert_equal(s0[0].axes_manager[0].units, 'nm')
+        nt.assert_equal(s0[0].axes_manager[0].name, 'y') # Should this name be y?
         nt.assert_almost_equal(s0[0].axes_manager[1].scale, 5.0, places=5)
         nt.assert_equal(s0[0].axes_manager[1].units, 'eV')
+        nt.assert_equal(s0[0].axes_manager[1].name, 'Energy')
         # s0[1] contains diffraction patterns
         nt.assert_equal(s0[1].data.shape, (5, 128, 128))
         nt.assert_equal(s0[1].axes_manager.signal_dimension, 2)
@@ -100,10 +104,13 @@ class TestFEIReader():
             s0[1].metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         nt.assert_almost_equal(s0[1].axes_manager[0].scale, 3.68864, places=5)
         nt.assert_equal(s0[1].axes_manager[0].units, 'nm')
-        nt.assert_equal(s0[1].axes_manager[1].units, '1/nm')
+        nt.assert_equal(s0[1].axes_manager[0].name, 'y') # Should this name be y?
         nt.assert_almost_equal(s0[1].axes_manager[1].scale, 0.17435, places=5)
+        nt.assert_equal(s0[1].axes_manager[1].units, '1/nm')
+        nt.assert_equal(s0[1].axes_manager[1].name, 'x')
         nt.assert_almost_equal(s0[1].axes_manager[2].scale, 0.17435, places=5)
         nt.assert_equal(s0[1].axes_manager[2].units, '1/nm')
+        nt.assert_equal(s0[1].axes_manager[2].name, 'y')
 
     def test_load_diffraction_area_scan(self):
         fname0 = os.path.join(
@@ -116,10 +123,13 @@ class TestFEIReader():
             s0[0].metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         nt.assert_almost_equal(s0[0].axes_manager[0].scale, 1.87390, places=5)
         nt.assert_equal(s0[0].axes_manager[0].units, 'nm')
+        nt.assert_equal(s0[0].axes_manager[0].name, 'x')
         nt.assert_almost_equal(s0[0].axes_manager[1].scale, -1.87390, places=5)
         nt.assert_equal(s0[0].axes_manager[1].units, 'nm')
+        nt.assert_equal(s0[0].axes_manager[1].name, 'y')
         nt.assert_almost_equal(s0[0].axes_manager[2].scale, 5.0, places=5)
         nt.assert_equal(s0[0].axes_manager[2].units, 'eV')
+        nt.assert_equal(s0[0].axes_manager[2].name, 'Energy')
         # s0[1] contains diffraction patterns
         nt.assert_equal(s0[1].data.shape, (5, 5, 256, 256))
         nt.assert_equal(s0[1].axes_manager.signal_dimension, 2)
@@ -127,8 +137,16 @@ class TestFEIReader():
             s0[1].metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         nt.assert_almost_equal(s0[1].axes_manager[0].scale, 1.87390, places=5)
         nt.assert_equal(s0[1].axes_manager[0].units, 'nm')
+        nt.assert_equal(s0[1].axes_manager[0].name, 'x')
+        nt.assert_almost_equal(s0[1].axes_manager[1].scale, -1.87390, places=5)
+        nt.assert_equal(s0[1].axes_manager[1].units, 'nm')
+        nt.assert_equal(s0[1].axes_manager[1].name, 'y')
         nt.assert_almost_equal(s0[1].axes_manager[2].scale, 0.17435, places=5)
         nt.assert_equal(s0[1].axes_manager[2].units, '1/nm')
+        nt.assert_equal(s0[1].axes_manager[2].name, 'x')
+        nt.assert_almost_equal(s0[1].axes_manager[3].scale, 0.17435, places=5)
+        nt.assert_equal(s0[1].axes_manager[3].units, '1/nm')
+        nt.assert_equal(s0[1].axes_manager[3].name, 'y')
 
     def test_load_spectrum_point(self):
         fname0 = os.path.join(

--- a/hyperspy/tests/io/test_fei.py
+++ b/hyperspy/tests/io/test_fei.py
@@ -398,13 +398,12 @@ class TestFEIReader():
         s = load(fname0)
         nt.assert_equal(s.metadata.General.date, "2016-02-21")
         nt.assert_equal(s.metadata.General.time, "17:50:18")
-        nt.assert_equal(s.metadata.General.authors, "ERIC")
 
         fname1 = os.path.join(self.dirpathold,
                               '16x16-line_profile_horizontal_10x1024.emi')
         s = load(fname1)
-        nt.assert_false(s.metadata.has_item('General.date'))
-        nt.assert_false(s.metadata.has_item('General.time'))
+        nt.assert_equal(s.metadata.General.date, "2016-02-22")
+        nt.assert_equal(s.metadata.General.time, "11:50:36")
 
     def test_metadata_TEM(self):
         fname0 = os.path.join(self.dirpathold, '64x64_TEM_images_acquire.emi')


### PR DESCRIPTION
- Doesn't mapped an empty string to metadata if the date and time are not available.
- Load date and time for line scan.
- Add tests to check the name, scale and units of the axes for the different kind of data.