### PR TITLE
pytest parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
       conda install pip;
       python setup.py install;
       pip install pytest pytest-xdist;
-    else pip install pytest pytest-xdist;
+    else pip install pytest;
     pip3 install .;
     fi
 
@@ -44,14 +44,12 @@ script:
   - if [[ $MINIMAL_ENV == 'False' ]]; then
       python setup.py build_ext --inplace;
       pip install coverage coveralls pytest-cov;
-      py.test -n 8 -m "not parallel" --cov=hyperspy --pyargs hyperspy;
-      py.test -m "parallel" --pyargs hyperspy;
+      py.test --cov=hyperspy --pyargs hyperspy;
     else python3 setup.py build_ext --inplace;
       echo "available installed python libraries (pip3 list):"
       pip3 list;
       pip3 install coverage coveralls pytest-cov;
-      py.test -n 8 -m "not parallel" --cov=hyperspy --pyargs hyperspy.tests;
-      py.test -m "parallel" --pyargs hyperspy.tests;
+      py.test --cov=hyperspy --pyargs hyperspy.tests;
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,14 @@ script:
   - if [[ $MINIMAL_ENV == 'False' ]]; then
       python setup.py build_ext --inplace;
       pip install coverage coveralls pytest-cov;
-      py.test -n 8 --cov=hyperspy --pyargs hyperspy;
+      py.test -n 8 -m "not parallel" --cov=hyperspy --pyargs hyperspy;
+      py.test -m "parallel" --pyargs hyperspy;
     else python3 setup.py build_ext --inplace;
       echo "available installed python libraries (pip3 list):"
       pip3 list;
       pip3 install coverage coveralls pytest-cov;
-      py.test -n 8 --cov=hyperspy --pyargs hyperspy.tests;
+      py.test -n 8 -m "not parallel" --cov=hyperspy --pyargs hyperspy.tests;
+      py.test -m "parallel" --pyargs hyperspy.tests;
     fi
 
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,8 +56,6 @@ install:
   - "%CMD_IN_ENV% conda install -yq %DEPS%"
     # Having 'sip' folder on path confuses import of `sip`.
   - "%CMD_IN_ENV% conda install pip"
-    # Install pytest-xdist, has to be done in pip
-  - "%CMD_IN_ENV% pip install pytest-xdist"
   # TODO: Remove once anaconda taitsui package is at v5:
   - "IF \"%PYTHON_MAJOR%\" EQU \"3\" pip install --upgrade traitsui tqdm"
   - ps: Add-AppveyorMessage "Installing hyperspy..."
@@ -69,8 +67,7 @@ test_script:
   # Run the project tests
   - ps: Add-AppveyorMessage "Running tests..."
   - "python setup.py build_ext --inplace"
-  - "py.test -m 'parallel'"
-  - "py.test -n auto -m 'not parallel'"
+  - "py.test"
   - "python setup.py clean"
   - ps: Add-AppveyorMessage "Testing completed."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,8 @@ test_script:
   # Run the project tests
   - ps: Add-AppveyorMessage "Running tests..."
   - "python setup.py build_ext --inplace"
-  - "py.test -n 8 --pyargs hyperspy"
+  - "py.test -n 8 -m 'not parallel' --pyargs hyperspy"
+  - "py.test -m 'parallel' --pyargs hyperspy"
   - "python setup.py clean"
   - ps: Add-AppveyorMessage "Testing completed."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,8 +69,8 @@ test_script:
   # Run the project tests
   - ps: Add-AppveyorMessage "Running tests..."
   - "python setup.py build_ext --inplace"
-  - "py.test -n 8 -m 'not parallel' --pyargs hyperspy"
-  - "py.test -m 'parallel' --pyargs hyperspy"
+  - "py.test -n auto -m 'not parallel' hyperspy/tests"
+  - "py.test -m 'parallel' hyperspy/tests"
   - "python setup.py clean"
   - ps: Add-AppveyorMessage "Testing completed."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,8 +69,8 @@ test_script:
   # Run the project tests
   - ps: Add-AppveyorMessage "Running tests..."
   - "python setup.py build_ext --inplace"
-  - "py.test -n auto -m 'not parallel' hyperspy/tests"
-  - "py.test -m 'parallel' hyperspy/tests"
+  - "py.test -m 'parallel'"
+  - "py.test -n auto -m 'not parallel'"
   - "python setup.py clean"
   - ps: Add-AppveyorMessage "Testing completed."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ shallow_clone: true
 environment:
 
   global:
-    TEST_DEPS: "pytest pytest-cov pytest-xdist wheel pip"
+    TEST_DEPS: "pytest pytest-cov wheel pip"
     NSIS_DIR: "%PROGRAMFILES(x86)%/NSIS"
 
 
@@ -56,6 +56,8 @@ install:
   - "%CMD_IN_ENV% conda install -yq %DEPS%"
     # Having 'sip' folder on path confuses import of `sip`.
   - "%CMD_IN_ENV% conda install pip"
+    # Install pytest-xdist, has to be done in pip
+  - "%CMD_IN_ENV% pip install pytest-xdist"
   # TODO: Remove once anaconda taitsui package is at v5:
   - "IF \"%PYTHON_MAJOR%\" EQU \"3\" pip install --upgrade traitsui tqdm"
   - ps: Add-AppveyorMessage "Installing hyperspy..."

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -30,7 +30,6 @@ from hyperspy.samfire_utils.strategy import (LocalStrategy,
                                              GlobalStrategy)
 from hyperspy.samfire_utils.local_strategies import ReducedChiSquaredStrategy
 from hyperspy.samfire_utils.global_strategies import HistogramStrategy
-from hyperspy.samfire_utils.samfire_pool import SamfirePool
 
 
 _logger = logging.getLogger(__name__)
@@ -205,6 +204,7 @@ class Samfire:
 
     def _setup(self, **kwargs):
         """Set up SAMFire - configure models, set up pool if necessary"""
+        from hyperspy.samfire_utils.samfire_pool import SamfirePool
         self._figure = None
         self.metadata._gt_dump = dill.dumps(self.metadata.goodness_test)
         self._enable_optional_components()

--- a/hyperspy/samfire_utils/goodness_of_fit_tests/red_chisq.py
+++ b/hyperspy/samfire_utils/goodness_of_fit_tests/red_chisq.py
@@ -33,5 +33,7 @@ class red_chisq_test(goodness_test):
             model.red_chisq.data[ind] - self.expected) < self.tolerance
 
     def map(self, model, mask):
-        ans = np.abs(model.red_chisq.data - self.expected) < self.tolerance
+        rc = model.red_chisq.data
+        rc = np.where(np.isnan(rc), -np.inf, rc)
+        ans = np.abs(rc - self.expected) < self.tolerance
         return np.logical_and(mask, ans)

--- a/hyperspy/samfire_utils/samfire_pool.py
+++ b/hyperspy/samfire_utils/samfire_pool.py
@@ -20,7 +20,6 @@
 import time
 import logging
 from multiprocessing import Manager
-from ipyparallel import Reference as ipp_Reference
 import numpy as np
 
 from hyperspy.utils.parallel_pool import ParallelPool
@@ -138,6 +137,7 @@ class SamfirePool(ParallelPool):
         optional_names = {mall[c].name for c in samfire.optional_components}
 
         if self.is_ipyparallel:
+            from ipyparallel import Reference as ipp_Reference
             _logger.debug('preparing ipyparallel workers')
             direct_view = self.pool.client[:self.num_workers]
             direct_view.block = True

--- a/hyperspy/samfire_utils/strategy.py
+++ b/hyperspy/samfire_utils/strategy.py
@@ -463,14 +463,16 @@ class GlobalStrategy(SamfireStrategy):
         """Refreshes the database (i.e. constructs it again from scratch)
         """
         scale = self.samf._scale
+        mark = self.samf.metadata.marker
+        mark = np.where(np.isnan(mark), np.inf, mark)
         if overwrite:
             if given_pixels is None:
-                good_pixels = self.samf.metadata.marker < 0
+                good_pixels = mark < 0
             else:
                 good_pixels = given_pixels
             self.samf.metadata.marker[good_pixels] = -scale
         else:
-            good_pixels = self.samf.metadata.marker < 0
+            good_pixels = mark < 0
             if given_pixels is not None:
                 good_pixels = np.logical_and(good_pixels, given_pixels)
         self.samf.metadata.marker[~good_pixels] = scale

--- a/hyperspy/tests/model/test_components.py
+++ b/hyperspy/tests/model/test_components.py
@@ -21,7 +21,7 @@ class TestPowerLaw:
 
     def test_estimate_parameters_binned_only_current(self):
         self.m.signal.metadata.Signal.binned = True
-        s = self.m.as_signal(show_progressbar=None)
+        s = self.m.as_signal(show_progressbar=None, parallel=False)
         s.metadata.Signal.binned = True
         g = hs.model.components1D.PowerLaw()
         g.estimate_parameters(s,
@@ -33,7 +33,7 @@ class TestPowerLaw:
 
     def test_estimate_parameters_unbinned_only_current(self):
         self.m.signal.metadata.Signal.binned = False
-        s = self.m.as_signal(show_progressbar=None)
+        s = self.m.as_signal(show_progressbar=None, parallel=False)
         s.metadata.Signal.binned = False
         g = hs.model.components1D.PowerLaw()
         g.estimate_parameters(s,
@@ -45,7 +45,7 @@ class TestPowerLaw:
 
     def test_estimate_parameters_binned(self):
         self.m.signal.metadata.Signal.binned = True
-        s = self.m.as_signal(show_progressbar=None)
+        s = self.m.as_signal(show_progressbar=None, parallel=False)
         s.metadata.Signal.binned = True
         g = hs.model.components1D.PowerLaw()
         g.estimate_parameters(s,
@@ -57,7 +57,7 @@ class TestPowerLaw:
 
     def test_estimate_parameters_unbinned(self):
         self.m.signal.metadata.Signal.binned = False
-        s = self.m.as_signal(show_progressbar=None)
+        s = self.m.as_signal(show_progressbar=None, parallel=False)
         s.metadata.Signal.binned = False
         g = hs.model.components1D.PowerLaw()
         g.estimate_parameters(s,
@@ -88,7 +88,7 @@ class TestOffset:
 
     def test_estimate_parameters_binned(self):
         self.m.signal.metadata.Signal.binned = True
-        s = self.m.as_signal(show_progressbar=None)
+        s = self.m.as_signal(show_progressbar=None, parallel=False)
         s.metadata.Signal.binned = True
         g = hs.model.components1D.Offset()
         g.estimate_parameters(s,
@@ -99,7 +99,7 @@ class TestOffset:
 
     def test_estimate_parameters_unbinned(self):
         self.m.signal.metadata.Signal.binned = False
-        s = self.m.as_signal(show_progressbar=None)
+        s = self.m.as_signal(show_progressbar=None, parallel=False)
         s.metadata.Signal.binned = False
         g = hs.model.components1D.Offset()
         g.estimate_parameters(s,
@@ -138,7 +138,7 @@ class TestPolynomial:
 
     def test_estimate_parameters_binned(self):
         self.m.signal.metadata.Signal.binned = True
-        s = self.m.as_signal(show_progressbar=None)
+        s = self.m.as_signal(show_progressbar=None, parallel=False)
         s.metadata.Signal.binned = True
         g = hs.model.components1D.Polynomial(order=2)
         g.estimate_parameters(s,
@@ -151,7 +151,7 @@ class TestPolynomial:
 
     def test_estimate_parameters_unbinned(self):
         self.m.signal.metadata.Signal.binned = False
-        s = self.m.as_signal(show_progressbar=None)
+        s = self.m.as_signal(show_progressbar=None, parallel=False)
         s.metadata.Signal.binned = False
         g = hs.model.components1D.Polynomial(order=2)
         g.estimate_parameters(s,
@@ -164,7 +164,7 @@ class TestPolynomial:
 
     def test_2d_signal(self):
         # This code should run smoothly, any exceptions should trigger failure
-        s = self.m_2d.as_signal(show_progressbar=None)
+        s = self.m_2d.as_signal(show_progressbar=None, parallel=False)
         model = Model1D(s)
         p = hs.model.components1D.Polynomial(order=2)
         model.append(p)
@@ -174,7 +174,7 @@ class TestPolynomial:
 
     def test_3d_signal(self):
         # This code should run smoothly, any exceptions should trigger failure
-        s = self.m_3d.as_signal(show_progressbar=None)
+        s = self.m_3d.as_signal(show_progressbar=None, parallel=False)
         model = Model1D(s)
         p = hs.model.components1D.Polynomial(order=2)
         model.append(p)
@@ -198,7 +198,7 @@ class TestGaussian:
 
     def test_estimate_parameters_binned(self):
         self.m.signal.metadata.Signal.binned = True
-        s = self.m.as_signal(show_progressbar=None)
+        s = self.m.as_signal(show_progressbar=None, parallel=False)
         s.metadata.Signal.binned = True
         g = hs.model.components1D.Gaussian()
         g.estimate_parameters(s,
@@ -211,7 +211,7 @@ class TestGaussian:
 
     def test_estimate_parameters_unbinned(self):
         self.m.signal.metadata.Signal.binned = False
-        s = self.m.as_signal(show_progressbar=None)
+        s = self.m.as_signal(show_progressbar=None, parallel=False)
         s.metadata.Signal.binned = False
         g = hs.model.components1D.Gaussian()
         g.estimate_parameters(s,

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -1035,57 +1035,55 @@ class TestAsSignal:
                                   show_progressbar=False, parallel=False)
             np.testing.assert_allclose(s1.data, s.data)
 
-    def test_all_components_simple(self):
-        for th in [True, False]:
-            s = self.m.as_signal(show_progressbar=False, parallel=th)
-            assert np.all(s.data == 4.)
+    @pytest.mark.parametrize('parallel', [True, False])
+    def test_all_components_simple(self, parallel):
+        s = self.m.as_signal(show_progressbar=False, parallel=parallel)
+        assert np.all(s.data == 4.)
 
-    def test_one_component_simple(self):
-        for th in [True, False]:
-            s = self.m.as_signal(component_list=[0], show_progressbar=False,
-                                 parallel=th)
-            assert np.all(s.data == 2.)
-            assert self.m[1].active
+    @pytest.mark.parametrize('parallel', [True, False])
+    def test_one_component_simple(self, parallel):
+        s = self.m.as_signal(component_list=[0], show_progressbar=False,
+                             parallel=parallel)
+        assert np.all(s.data == 2.)
+        assert self.m[1].active
 
-    def test_all_components_multidim(self):
+    @pytest.mark.parametrize('parallel', [True, False])
+    def test_all_components_multidim(self, parallel):
         self.m[0].active_is_multidimensional = True
 
-        for th in [True, False]:
-            s = self.m.as_signal(show_progressbar=False, parallel=th)
-            assert np.all(s.data == 4.)
+        s = self.m.as_signal(show_progressbar=False, parallel=parallel)
+        assert np.all(s.data == 4.)
 
         self.m[0]._active_array[0] = False
-        for th in [True, False]:
-            s = self.m.as_signal(show_progressbar=False, parallel=th)
-            np.testing.assert_array_equal(
-                s.data, np.array([np.ones((2, 5)) * 2, np.ones((2, 5)) * 4]))
-            assert self.m[0].active_is_multidimensional
+        s = self.m.as_signal(show_progressbar=False, parallel=parallel)
+        np.testing.assert_array_equal(
+            s.data, np.array([np.ones((2, 5)) * 2, np.ones((2, 5)) * 4]))
+        assert self.m[0].active_is_multidimensional
 
-    def test_one_component_multidim(self):
+    @pytest.mark.parametrize('parallel', [True, False])
+    def test_one_component_multidim(self, parallel):
         self.m[0].active_is_multidimensional = True
 
-        for th in [True, False]:
-            s = self.m.as_signal(component_list=[0], show_progressbar=False,
-                                 parallel=th)
-            assert np.all(s.data == 2.)
-            assert self.m[1].active
-            assert not self.m[1].active_is_multidimensional
+        s = self.m.as_signal(component_list=[0], show_progressbar=False,
+                             parallel=parallel)
+        assert np.all(s.data == 2.)
+        assert self.m[1].active
+        assert not self.m[1].active_is_multidimensional
 
-            s = self.m.as_signal(component_list=[1], show_progressbar=False,
-                                 parallel=th)
-            np.testing.assert_equal(s.data, 2.)
-            assert self.m[0].active_is_multidimensional
+        s = self.m.as_signal(component_list=[1], show_progressbar=False,
+                             parallel=parallel)
+        np.testing.assert_equal(s.data, 2.)
+        assert self.m[0].active_is_multidimensional
 
         self.m[0]._active_array[0] = False
-        for th in [True, False]:
-            s = self.m.as_signal(component_list=[1], show_progressbar=False,
-                                 parallel=th)
-            assert np.all(s.data == 2.)
+        s = self.m.as_signal(component_list=[1], show_progressbar=False,
+                             parallel=parallel)
+        assert np.all(s.data == 2.)
 
-            s = self.m.as_signal(component_list=[0], show_progressbar=False,
-                                 parallel=th)
-            np.testing.assert_array_equal(s.data, np.array([np.zeros((2, 5)),
-                                                            np.ones((2, 5)) * 2]))
+        s = self.m.as_signal(component_list=[0], show_progressbar=False,
+                             parallel=parallel)
+        np.testing.assert_array_equal(s.data, np.array([np.zeros((2, 5)),
+                                                        np.ones((2, 5)) * 2]))
 
 
 class TestCreateModel:

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -310,7 +310,8 @@ class TestModel1D:
         # tests
         np.testing.assert_array_equal(m.convolution_axis, np.arange(7, 23))
         np.testing.assert_equal(ll_axis.value2index.call_args[0][0], 0)
-
+    
+    @pytest.mark.parallel
     def test_notebook_interactions(self):
         ipywidgets = pytest.importorskip("ipywidgets", minversion="5.0")
         ipython = pytest.importorskip("IPython")
@@ -1019,6 +1020,7 @@ class TestAsSignal:
             c.offset.value = 2
         self.m.assign_current_values_to_all()
 
+    @pytest.mark.parallel
     def test_threaded_identical(self):
         # all components
         s = self.m.as_signal(show_progressbar=False, parallel=True)
@@ -1035,19 +1037,19 @@ class TestAsSignal:
                                   show_progressbar=False, parallel=False)
             np.testing.assert_allclose(s1.data, s.data)
 
-    @pytest.mark.parametrize('parallel', [True, False])
+    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
     def test_all_components_simple(self, parallel):
         s = self.m.as_signal(show_progressbar=False, parallel=parallel)
         assert np.all(s.data == 4.)
 
-    @pytest.mark.parametrize('parallel', [True, False])
+    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
     def test_one_component_simple(self, parallel):
         s = self.m.as_signal(component_list=[0], show_progressbar=False,
                              parallel=parallel)
         assert np.all(s.data == 2.)
         assert self.m[1].active
 
-    @pytest.mark.parametrize('parallel', [True, False])
+    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
     def test_all_components_multidim(self, parallel):
         self.m[0].active_is_multidimensional = True
 
@@ -1060,7 +1062,7 @@ class TestAsSignal:
             s.data, np.array([np.ones((2, 5)) * 2, np.ones((2, 5)) * 4]))
         assert self.m[0].active_is_multidimensional
 
-    @pytest.mark.parametrize('parallel', [True, False])
+    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
     def test_one_component_multidim(self, parallel):
         self.m[0].active_is_multidimensional = True
 

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -144,7 +144,7 @@ class TestSamfireEmpty:
 
     def setup_method(self, method):
         self.shape = (7, 15)
-        s = hs.signals.Signal1D(np.ones(self.shape + (1024,)+3.))
+        s = hs.signals.Signal1D(np.ones(self.shape + (1024,))+3.)
         s.estimate_poissonian_noise_variance()
         m = s.create_model()
         m.append(hs.model.components1D.Gaussian())

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -17,13 +17,13 @@
 
 
 import numpy as np
+import pytest
 
 import dill
 import copy
 import hyperspy.api as hs
 from hyperspy.samfire_utils.samfire_kernel import multi_kernel
 from hyperspy.misc.utils import DictionaryTreeBrowser
-from hyperspy.samfire import StrategyList
 from hyperspy.samfire_utils.samfire_worker import create_worker
 
 
@@ -102,7 +102,7 @@ def generate_test_model():
         gs03.A.map['values'][mask] *= 0.
         gs03.A.map['is_set'][:] = True
 
-        s11 = m0.as_signal(show_progressbar=False)
+        s11 = m0.as_signal(show_progressbar=False, parallel=False)
         if total is None:
             total = s11.data.copy()
             lor_map = gs01.centre.map['values'].copy()
@@ -140,7 +140,6 @@ def generate_test_model():
     l2.active_is_multidimensional = True
     return m, gs01, gs02, gs03
 
-
 class TestSamfireEmpty:
 
     def setup_method(self, method):
@@ -153,6 +152,7 @@ class TestSamfireEmpty:
         m.append(hs.model.components1D.Lorentzian())
         self.model = m
 
+    @pytest.mark.parallel
     def test_setup(self):
         m = self.model
         samf = m.create_samfire(workers=1, setup=False)
@@ -179,6 +179,7 @@ class TestSamfireEmpty:
         assert isinstance(samf.metadata, DictionaryTreeBrowser)
 
     def test_samfire_init_strategy_list(self):
+        from hyperspy.samfire import StrategyList
         m = self.model
         samf = m.create_samfire(workers=1, setup=False)
         assert isinstance(samf.strategies, StrategyList)

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -144,7 +144,7 @@ class TestSamfireEmpty:
 
     def setup_method(self, method):
         self.shape = (7, 15)
-        s = hs.signals.Signal1D(np.empty(self.shape + (1024,)))
+        s = hs.signals.Signal1D(np.ones(self.shape + (1024,)+3.))
         s.estimate_poissonian_noise_variance()
         m = s.create_model()
         m.append(hs.model.components1D.Gaussian())

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -262,7 +262,8 @@ class TestSmoothing:
         np.random.seed(1)
         self.s.add_gaussian_noise(0.1)
 
-    def test_lowess(self):
+    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    def test_lowess(self, parallel):
         pytest.importorskip("statsmodels")
         from statsmodels.nonparametric.smoothers_lowess import lowess
         frac = 0.5
@@ -278,10 +279,12 @@ class TestSmoothing:
                 return_sorted=False,)
         self.s.smooth_lowess(smoothing_parameter=frac,
                              number_of_iterations=it,
-                             show_progressbar=None)
+                             show_progressbar=None,
+                             parallel=parallel)
         assert np.allclose(data, self.s.data)
 
-    def test_tv(self):
+    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    def test_tv(self, parallel):
         weight = 1
         data = self.s.data.astype('float')
         for i in range(data.shape[0]):
@@ -289,7 +292,8 @@ class TestSmoothing:
                 im=data[i, :],
                 weight=weight,)
         self.s.smooth_tv(smoothing_parameter=weight,
-                         show_progressbar=None)
+                         show_progressbar=None,
+                         parallel=parallel)
         assert np.allclose(data, self.s.data)
 
     def test_savgol(self):

--- a/hyperspy/tests/signal/test_complex_signal.py
+++ b/hyperspy/tests/signal/test_complex_signal.py
@@ -20,6 +20,7 @@
 import numpy as np
 import numpy.testing as nt
 from numpy.testing import assert_allclose
+import pytest
 
 import hyperspy.api as hs
 
@@ -79,31 +80,37 @@ class TestComplexProperties:
             np.pi)
 
 
-def test_get_unwrapped_phase_1D():
+@pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+def test_get_unwrapped_phase_1D(parallel):
     phase = 6 * (1 - np.abs(np.indices((9,)) - 4) / 4)
     s = hs.signals.ComplexSignal(np.ones_like(phase) * np.exp(1j * phase))
     s.axes_manager.set_signal_dimension(1)
-    phase_unwrapped = s.unwrapped_phase(seed=42, show_progressbar=False)
+    phase_unwrapped = s.unwrapped_phase(seed=42, show_progressbar=False,
+                                        parallel=parallel)
     assert (
         phase_unwrapped.metadata.General.title ==
         'unwrapped phase(Untitled Signal)')
     assert_allclose(phase_unwrapped.data, phase)
 
 
-def test_get_unwrapped_phase_2D():
+@pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+def test_get_unwrapped_phase_2D(parallel):
     phase = 5 * (1 - np.abs(np.indices((9, 9)) - 4).sum(axis=0) / 8)
     s = hs.signals.ComplexSignal(np.ones_like(phase) * np.exp(1j * phase))
-    phase_unwrapped = s.unwrapped_phase(seed=42, show_progressbar=False)
+    phase_unwrapped = s.unwrapped_phase(seed=42, show_progressbar=False,
+                                        parallel=parallel)
     assert (
         phase_unwrapped.metadata.General.title ==
         'unwrapped phase(Untitled Signal)')
     assert_allclose(phase_unwrapped.data, phase)
 
 
-def test_get_unwrapped_phase_3D():
+@pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+def test_get_unwrapped_phase_3D(parallel):
     phase = 4 * (1 - np.abs(np.indices((9, 9, 9)) - 4).sum(axis=0) / 12)
     s = hs.signals.ComplexSignal(np.ones_like(phase) * np.exp(1j * phase))
-    phase_unwrapped = s.unwrapped_phase(seed=42, show_progressbar=False)
+    phase_unwrapped = s.unwrapped_phase(seed=42, show_progressbar=False,
+                                        parallel=parallel)
     assert (
         phase_unwrapped.metadata.General.title ==
         'unwrapped phase(Untitled Signal)')

--- a/hyperspy/tests/signal/test_hologram_image.py
+++ b/hyperspy/tests/signal/test_hologram_image.py
@@ -96,13 +96,14 @@ class TestCaseHologramImage(object):
         assert (
             self.holo_image.metadata.Acquisition_instrument.TEM.tilt_stage == 2.2)
 
-    def test_reconstruct_phase(self):
+    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    def test_reconstruct_phase(self, parallel):
 
         # 1. Testing reconstruction of a single hologram with a reference (as a np array and as HologramImage) with
         # default output size with an without input sideband parameters:
 
         wave_image = self.holo_image.reconstruct_phase(
-            self.ref, store_parameters=True)
+            self.ref, store_parameters=True, parallel=parallel)
         sb_pos_cc = wave_image.metadata.Signal.Holography.Reconstruction_parameters.sb_position * (-1) + \
             [self.img_size, self.img_size]
 
@@ -110,7 +111,9 @@ class TestCaseHologramImage(object):
         sb_smoothness_cc = wave_image.metadata.Signal.Holography.Reconstruction_parameters.sb_smoothness
         sb_units_cc = wave_image.metadata.Signal.Holography.Reconstruction_parameters.sb_units
         wave_image_cc = self.holo_image.reconstruct_phase(self.ref_image, sb_position=sb_pos_cc, sb_size=sb_size_cc,
-                                                          sb_smoothness=sb_smoothness_cc, sb_unit=sb_units_cc)
+                                                          sb_smoothness=sb_smoothness_cc,
+                                                          sb_unit=sb_units_cc,
+                                                         parallel=parallel)
         x_start = int(wave_image.axes_manager.signal_shape[0] / 10)
         x_stop = int(wave_image.axes_manager.signal_shape[0] * 9 / 10)
         wave_crop = wave_image.data[x_start:x_stop, x_start:x_stop]
@@ -125,14 +128,17 @@ class TestCaseHologramImage(object):
         x_start = int(self.img_size / 10)
         x_stop = self.img_size - 1 - int(self.img_size / 10)
         phase_new_crop = wave_image.unwrapped_phase(
+            parallel=parallel
         ).data[x_start:x_stop, x_start:x_stop]
         phase_ref_crop = self.phase_ref[x_start:x_stop, x_start:x_stop]
         assert_allclose(phase_new_crop, phase_ref_crop, atol=1E-2)
 
         # 2. Testing reconstruction with non-standard output size for stacked
         # images:
-        sb_position2 = self.ref_image2.estimate_sideband_position(sb='upper')
-        sb_size2 = self.ref_image2.estimate_sideband_size(sb_position2)
+        sb_position2 = self.ref_image2.estimate_sideband_position(sb='upper',
+                                                                  parallel=parallel)
+        sb_size2 = self.ref_image2.estimate_sideband_size(sb_position2,
+                                                          parallel=parallel)
         output_shape = (
             np.int(
                 sb_size2.inav[0].data *
@@ -143,24 +149,26 @@ class TestCaseHologramImage(object):
 
         wave_image2 = self.holo_image2.reconstruct_phase(reference=self.ref_image2, sb_position=sb_position2,
                                                          sb_size=sb_size2, sb_smoothness=sb_size2 * 0.05,
-                                                         output_shape=output_shape)
+                                                         output_shape=output_shape,
+                                                        parallel=parallel)
         # a. Reconstruction with parameters provided as ndarrays should be
         # identical to above:
         wave_image2a = self.holo_image2.reconstruct_phase(reference=self.ref_image2.data, sb_position=sb_position2.data,
                                                           sb_size=sb_size2.data, sb_smoothness=sb_size2.data * 0.05,
-                                                          output_shape=output_shape)
+                                                          output_shape=output_shape,
+                                                         parallel=parallel)
         assert wave_image2 == wave_image2a
 
         # interpolate reconstructed phase to compare with the input (reference
         # phase):
         interp_x = np.arange(output_shape[0])
         phase_interp0 = interp2d(interp_x, interp_x, wave_image2.inav[
-                                 0].unwrapped_phase().data, kind='cubic')
+                                 0].unwrapped_phase(parallel=parallel).data, kind='cubic')
         phase_new0 = phase_interp0(np.linspace(0, output_shape[0], self.img_size),
                                    np.linspace(0, output_shape[0], self.img_size))
 
         phase_interp1 = interp2d(interp_x, interp_x, wave_image2.inav[
-                                 1].unwrapped_phase().data, kind='cubic')
+                                 1].unwrapped_phase(parallel=parallel).data, kind='cubic')
         phase_new1 = phase_interp1(np.linspace(0, output_shape[0], self.img_size),
                                    np.linspace(0, output_shape[0], self.img_size))
 
@@ -176,7 +184,7 @@ class TestCaseHologramImage(object):
         # 3. Testing reconstruction with multidimensional images (3, 2| 512,
         # 768) using 1d image as a reference:
         wave_image3 = self.holo_image3.reconstruct_phase(
-            self.ref_image3.inav[0, 0], sb='upper')
+            self.ref_image3.inav[0, 0], sb='upper', parallel=parallel)
 
         # Cropping the reconstructed and original phase images and comparing:
         x_start = int(self.img_size3x / 9)
@@ -184,7 +192,7 @@ class TestCaseHologramImage(object):
         x_stop = self.img_size3x - 1 - int(self.img_size3x / 9)
         y_start = int(self.img_size3y / 9)
         y_stop = self.img_size3y - 1 - int(self.img_size3y / 9)
-        phase3_new_crop = wave_image3.unwrapped_phase()
+        phase3_new_crop = wave_image3.unwrapped_phase(parallel=parallel)
         phase3_new_crop.crop(2, y_start, y_stop)
         phase3_new_crop.crop(3, x_start, x_stop)
         phase3_ref_crop = self.phase_ref3.reshape(2, 3, self.img_size3x, self.img_size3y)[:, :, x_start:x_stop,
@@ -197,19 +205,21 @@ class TestCaseHologramImage(object):
         # 3a. Testing reconstruction with input parameters in 'nm' and with multiple parameter input,
         # but reference ndim=0:
 
-        sb_position3 = self.ref_image3.estimate_sideband_position(sb='upper')
+        sb_position3 = self.ref_image3.estimate_sideband_position(sb='upper',
+                                                                  parallel=parallel)
         f_sampling = np.divide(1, [a * b for a, b in zip(self.ref_image3.axes_manager.signal_shape,
                                                          (self.ref_image3.axes_manager.signal_axes[0].scale,
                                                           self.ref_image3.axes_manager.signal_axes[1].scale))])
         sb_size3 = self.ref_image3.estimate_sideband_size(
-            sb_position3) * np.mean(f_sampling)
+            sb_position3, parallel=parallel) * np.mean(f_sampling)
         sb_smoothness3 = sb_size3 * 0.05
         sb_units3 = 'nm'
 
         wave_image3a = self.holo_image3.reconstruct_phase(self.ref_image3.inav[0, 0], sb_position=sb_position3,
                                                           sb_size=sb_size3, sb_smoothness=sb_smoothness3,
-                                                          sb_unit=sb_units3)
-        phase3a_new_crop = wave_image3a.unwrapped_phase()
+                                                          sb_unit=sb_units3,
+                                                          parallel=parallel)
+        phase3a_new_crop = wave_image3a.unwrapped_phase(parallel=parallel)
         phase3a_new_crop.crop(2, y_start, y_stop)
         phase3a_new_crop.crop(3, x_start, x_stop)
         assert_allclose(
@@ -221,22 +231,26 @@ class TestCaseHologramImage(object):
         # a. Mismatch of navigation dimensions of object and reference
         # holograms, except if reference hologram ndim=0
         with pytest.raises(ValueError):
-            self.holo_image3.reconstruct_phase(self.ref_image3.inav[0, :])
+            self.holo_image3.reconstruct_phase(self.ref_image3.inav[0, :],
+                                               parallel=parallel)
         reference4a = self.ref_image3.inav[0, :]
         reference4a.set_signal_type('signal2d')
         with pytest.raises(ValueError):
-            self.holo_image3.reconstruct_phase(reference=reference4a)
+            self.holo_image3.reconstruct_phase(reference=reference4a,
+                                               parallel=parallel)
         #   b. Mismatch of signal shapes of object and reference holograms
         with pytest.raises(ValueError):
             self.holo_image3.reconstruct_phase(
-                self.ref_image3.inav[:, :].isig[y_start:y_stop, x_start:x_stop])
+                self.ref_image3.inav[:, :].isig[y_start:y_stop,
+                                                x_start:x_stop],
+                parallel=parallel)
 
         #   c. Mismatch of signal shape of sb_position
         sb_position_mismatched = hs.signals.Signal2D(
             np.arange(9).reshape((3, 3)))
         with pytest.raises(ValueError):
             self.holo_image3.reconstruct_phase(
-                sb_position=sb_position_mismatched)
+                sb_position=sb_position_mismatched, parallel=parallel)
         #   d. Mismatch of navigation dimensions of reconstruction parameters
         sb_position_mismatched = hs.signals.Signal1D(
             np.arange(16).reshape((8, 2)))
@@ -244,16 +258,18 @@ class TestCaseHologramImage(object):
         sb_smoothness_mismatched = hs.signals.BaseSignal(np.arange(9)).T
         with pytest.raises(ValueError):
             self.holo_image3.reconstruct_phase(
-                sb_position=sb_position_mismatched)
+                sb_position=sb_position_mismatched, parallel=parallel)
         with pytest.raises(ValueError):
-            self.holo_image3.reconstruct_phase(sb_size=sb_size_mismatched)
+            self.holo_image3.reconstruct_phase(sb_size=sb_size_mismatched,
+                                               parallel=parallel)
         with pytest.raises(ValueError):
             self.holo_image3.reconstruct_phase(
-                sb_smoothness=sb_smoothness_mismatched)
+                sb_smoothness=sb_smoothness_mismatched, parallel=parallel)
 
         #   e. Beam energy is not assigned, while 'mrad' units selected
         with pytest.raises(AttributeError):
-            self.holo_image3.reconstruct_phase(sb_size=40, sb_unit='mrad')
+            self.holo_image3.reconstruct_phase(sb_size=40, sb_unit='mrad',
+                                               parallel=parallel)
 
 if __name__ == '__main__':
 

--- a/hyperspy/utils/parallel_pool.py
+++ b/hyperspy/utils/parallel_pool.py
@@ -21,7 +21,6 @@ import time
 import logging
 from multiprocessing import (cpu_count, Pool)
 from multiprocessing.pool import Pool as Pool_type
-import ipyparallel as ipp
 import numpy as np
 
 _logger = logging.getLogger(__name__)
@@ -121,6 +120,7 @@ class ParallelPool:
             self.pool._state is 0
 
     def _setup_ipyparallel(self):
+        import ipyparallel as ipp
         _logger.debug('Calling _setup_ipyparallel')
         try:
             ipyclient = ipp.Client(**self.ipython_kwargs)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    parallel: a test that is itself parallel and should be run serially


### PR DESCRIPTION
 - added parallel flags to tests that fail without it (at least on linux, the windows tempfile deletion I'll leave to someone else)
 - fixed tests that were in fact parallel but did not have the parameter
 - made the parametrization pytest-like
 - added `parallel` kwds to methods that missed it, as discovered by tests
 - fixed appveyor pytest-xdist install
 - travis runs pytest twice - once in parallel, the second time for tests that fail in parallel but are fine in one process (essentially the ones that create more processes themselves).
 - appveyor does not seem to understand flags for py.test -- hence now just runs everything in one core. Still fails the tempfile things somehow...