### PR TITLE
Revert "Remove redundant drawing connection."

### DIFF
--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -85,10 +85,6 @@ class Signal1DFigure(BlittedFigure):
             line.sf_lines = self.right_ax_lines
             if line.axes_manager is None:
                 line.axes_manager = self.right_axes_manager
-        line.axes_manager.events.indices_changed.connect(line.update, [])
-        self.events.closed.connect(
-            lambda: line.axes_manager.events.indices_changed.disconnect(
-                line.update), [])
         line.axis = self.axis
         # Automatically asign the color if not defined
         if line.color is None:
@@ -114,6 +110,11 @@ class Signal1DFigure(BlittedFigure):
         for marker in self.ax_markers:
             marker.plot()
         plt.xlim(np.min(x_axis_lower_lims), np.max(x_axis_upper_lims))
+        # To be discussed
+        self.axes_manager.events.indices_changed.connect(self.update, [])
+        self.events.closed.connect(
+            lambda: self.axes_manager.events.indices_changed.disconnect(
+                self.update), [])
         self.ax.figure.canvas.draw_idle()
         if hasattr(self.figure, 'tight_layout'):
             try:
@@ -285,6 +286,10 @@ class Signal1DLine(object):
         self.line, = self.ax.plot(self.axis.axis, data,
                                   **self.line_properties)
         self.line.set_animated(self.ax.figure.canvas.supports_blit)
+        self.axes_manager.events.indices_changed.connect(self.update, [])
+        self.events.closed.connect(
+            lambda: self.axes_manager.events.indices_changed.disconnect(
+                self.update), [])
         if not self.axes_manager or self.axes_manager.navigation_size == 0:
             self.plot_indices = False
         if self.plot_indices is True:


### PR DESCRIPTION
Reverts francisco-dlp/hyperspy#40

I merged this after running the drawing tests locally and they seemed to pass (although now I can't understand why), but travis fails and running locally all the tests I get the following errors:

```
    1810 passed
       1 xpassed
      32 failed
         - hyperspy/tests/datasets/test_eelsdb.py:14 test_eelsdb_eels
         - hyperspy/tests/datasets/test_eelsdb.py:45 test_eelsdb_xas
         - hyperspy/misc/test_utils.py:182 test_plot_text_markers_close
         - hyperspy/tests/drawing/test_plot_markers.py:139 TestMarkers.test_add_marker_signal1d_navigation_dim
         - hyperspy/tests/drawing/test_plot_markers.py:159 TestMarkers.test_add_markers_as_list
         - hyperspy/tests/drawing/test_plot_markers.py:169 Test_permanent_markers.test_add_permanent_marker
         - hyperspy/tests/drawing/test_plot_markers.py:181 Test_permanent_markers.test_remove_permanent_marker_name
         - hyperspy/tests/drawing/test_plot_markers.py:190 Test_permanent_markers.test_permanent_marker_names
         - hyperspy/tests/drawing/test_plot_markers.py:203 Test_permanent_markers.test_add_permanent_marker_twice
         - hyperspy/tests/drawing/test_plot_markers.py:210 Test_permanent_markers.test_add_permanent_marker_twice_different_signal
         - hyperspy/tests/drawing/test_plot_markers.py:218 Test_permanent_markers.test_add_several_permanent_markers
         - hyperspy/tests/drawing/test_plot_markers.py:240 Test_permanent_markers.test_add_markers_as_list
         - hyperspy/tests/drawing/test_plot_markers.py:248 Test_permanent_markers.test_add_markers_as_list_add_same_twice
         - hyperspy/tests/drawing/test_plot_markers.py:257 Test_permanent_markers.test_add_markers_as_list_add_different_twice
         - hyperspy/tests/drawing/test_plot_markers.py:421 test_plot_text_markers_nav
         - hyperspy/tests/drawing/test_plot_markers.py:428 test_plot_text_markers_sig
         - hyperspy/tests/io/test_bcf.py:26 test_load_16bit
         - hyperspy/tests/io/test_bcf.py:44 test_load_16bit_reduced
         - hyperspy/tests/io/test_bcf.py:62 test_load_8bit
         - hyperspy/tests/io/test_bcf.py:75 test_hyperspy_wrap
         - hyperspy/tests/io/test_bcf.py:134 test_hyperspy_wrap_downsampled
         - hyperspy/tests/io/test_bcf.py:149 test_get_mode
         - hyperspy/tests/io/test_bcf.py:177 test_fast_bcf
         - hyperspy/tests/io/test_msa.py:324 test_minimum_metadata_example
         - hyperspy/tests/model/test_edsmodel.py:158 TestlineFit.test_enable_adjust_position
         - hyperspy/tests/model/test_edsmodel.py:158 TestlineFit.test_lazy_enable_adjust_position
         - hyperspy/tests/model/test_model.py:1111 TestAdjustPosition.test_disable_adjust_position
         - hyperspy/tests/model/test_model.py:1128 TestAdjustPosition.test_manual_close
         - hyperspy/tests/signal/test_eds_tem.py:319 Test_eds_markers.test_plot_auto_add
         - hyperspy/tests/signal/test_eds_tem.py:327 Test_eds_markers.test_manual_add_line
         - hyperspy/tests/signal/test_eds_tem.py:337 Test_eds_markers.test_manual_remove_element
         - hyperspy/tests/signal/test_tools.py:863 test_spikes_removal_tool
       8 error
       3 xfailed
      23 skipped
```