### PR TITLE
[SPLIT-IO] Keep support for passing hyperspy to `file_write`

### DIFF
--- a/rosettascio/rsciio/msa/api.py
+++ b/rosettascio/rsciio/msa/api.py
@@ -20,11 +20,8 @@ from datetime import datetime as dt
 import codecs
 import os
 import logging
-from pydoc import doc
-from turtle import dot
 
 import numpy as np
-from traits.api import Undefined
 
 from rsciio.version import __version__
 from rsciio.utils.tools import DTBox
@@ -209,7 +206,7 @@ def parse_msa_string(string, filename=None):
                 error = f"The {parameter} keyword value, {value} could \
                     not be converted to the right type."
                 if 'e' in value.lower():
-                    # Normally, the offending misspelling is a space in the 
+                    # Normally, the offending misspelling is a space in the
                     # scientific notation, e.g. 2.0 E-06
                     try:
                         parameters[parameter] = type_(value.replace(' ', ''))
@@ -317,6 +314,15 @@ def file_writer(filename, signal, format=None, separator=', ',
                 encoding='latin-1'):
     loc_kwds = {}
     FORMAT = "EMSA/MAS Spectral Data File"
+    # Keep support for passing hyperspy signal until hyperspy 2.0 is released
+    if not isinstance(signal, dict):
+        try:
+            signal = signal._to_dictionary()
+        except Exception:
+            raise ValueError(
+                "The argument `signal` must be a dictionary or a hyperspy signal."
+                )
+
     md = DTBox(signal["metadata"], box_dots=True)
     if signal["original_metadata"].get("FORMAT", None) == FORMAT:
         loc_kwds = signal["original_metadata"]
@@ -333,7 +339,7 @@ def file_writer(filename, signal, format=None, separator=', ',
             date_str = date.strftime("%d-%m-%Y")
             day, month, year = date_str.split("-")
             month = US_MONTHS_D2A[month]
-            loc_kwds['DATE'] = "-".join((day, month, year)) 
+            loc_kwds['DATE'] = "-".join((day, month, year))
         if "General.item" in md:
             time = dt.strptime(md.General.time, "%H:%M:%S")
             loc_kwds['TIME'] = time.strftime("%H:%M")

--- a/rosettascio/rsciio/msa/api.py
+++ b/rosettascio/rsciio/msa/api.py
@@ -24,7 +24,7 @@ import logging
 import numpy as np
 
 from rsciio.version import __version__
-from rsciio.utils.tools import DTBox
+from rsciio.utils.tools import DTBox, file_writer_parse_argument
 
 _logger = logging.getLogger(__name__)
 
@@ -307,22 +307,14 @@ def file_reader(filename, encoding='latin-1', **kwds):
             encoding=encoding,
             errors='replace') as spectrum_file:
         return parse_msa_string(string=spectrum_file,
-                                filename=filename)
+                               filename=filename)
 
 
+@file_writer_parse_argument()
 def file_writer(filename, signal, format=None, separator=', ',
                 encoding='latin-1'):
     loc_kwds = {}
     FORMAT = "EMSA/MAS Spectral Data File"
-    # Keep support for passing hyperspy signal until hyperspy 2.0 is released
-    if not isinstance(signal, dict):
-        try:
-            signal = signal._to_dictionary()
-        except Exception:
-            raise ValueError(
-                "The argument `signal` must be a dictionary or a hyperspy signal."
-                )
-
     md = DTBox(signal["metadata"], box_dots=True)
     if signal["original_metadata"].get("FORMAT", None) == FORMAT:
         loc_kwds = signal["original_metadata"]

--- a/rosettascio/rsciio/tests/test_msa.py
+++ b/rosettascio/rsciio/tests/test_msa.py
@@ -2,9 +2,12 @@ import copy
 import os.path
 import tempfile
 
-from hyperspy.io import load
+import hyperspy.api as hs
 from hyperspy.misc.test_utils import assert_deep_almost_equal
 from hyperspy import __version__ as hs_version
+
+from rsciio.msa.api import file_writer
+
 
 my_path = os.path.dirname(__file__)
 
@@ -169,7 +172,7 @@ example2_parameters = {
 class TestExample1:
 
     def setup_method(self, method):
-        self.s = load(os.path.join(
+        self.s = hs.load(os.path.join(
             my_path,
             "msa_files",
             "example1.msa"))
@@ -213,7 +216,7 @@ class TestExample1:
         with tempfile.TemporaryDirectory() as tmpdir:
             fname2 = os.path.join(tmpdir, "example1-export.msa")
             self.s.save(fname2)
-            s2 = load(fname2)
+            s2 = hs.load(fname2)
             # delete timestamp from metadata since it's runtime dependent
             del s2.metadata.General.FileIO.Number_0.timestamp
             del self.s.metadata.General.FileIO.Number_1
@@ -228,7 +231,7 @@ class TestExample1:
 class TestExample1WrongDate:
 
     def setup_method(self, method):
-        self.s = load(os.path.join(
+        self.s = hs.load(os.path.join(
             my_path,
             "msa_files",
             "example1_wrong_date.msa"))
@@ -244,12 +247,10 @@ class TestExample1WrongDate:
                                  md)
 
 
-
-
 class TestExample2:
 
     def setup_method(self, method):
-        self.s = load(os.path.join(
+        self.s = hs.load(os.path.join(
             my_path,
             "msa_files",
             "example2.msa"))
@@ -352,7 +353,7 @@ class TestExample2:
         with tempfile.TemporaryDirectory() as tmpdir:
             fname2 = os.path.join(tmpdir, "example2-export.msa")
             self.s.save(fname2)
-            s2 = load(fname2)
+            s2 = hs.load(fname2)
             assert (s2.metadata.General.original_filename ==
                     "example2-export.msa")
             s2.metadata.General.original_filename = "example2.msa"
@@ -364,5 +365,11 @@ class TestExample2:
 
 
 def test_minimum_metadata_example():
-    s = load(os.path.join(my_path, "msa_files", "minimum_metadata.msa"))
+    s = hs.load(os.path.join(my_path, "msa_files", "minimum_metadata.msa"))
     assert minimum_md_om == s.original_metadata.as_dictionary()
+
+
+def test_file_writer_hs_signal(tmp_path):
+    fname = tmp_path / 'test_file.prz'
+    s = hs.signals.Signal1D([0, 1, 2])
+    file_writer(fname, s)

--- a/rosettascio/rsciio/utils/tools.py
+++ b/rosettascio/rsciio/utils/tools.py
@@ -22,7 +22,6 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 import os
 from collections import OrderedDict
-from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 
 import numpy as np
@@ -34,9 +33,29 @@ _UREG = UnitRegistry()
 
 _logger = logging.getLogger(__name__)
 
+
 @contextmanager
 def dummy_context_manager(*args, **kwargs):
     yield
+
+
+def file_writer_parse_argument():
+    def decorator(func):
+        def parse_argument(filename, signal, **kwargs):
+            # Keep support for passing hyperspy signal until hyperspy 2.0
+            # is released
+            if not isinstance(signal, dict):
+                try:
+                    signal = signal._to_dictionary()
+                except Exception:
+                    raise ValueError(
+                        "The argument `signal` must be a dictionary or a "
+                        "hyperspy signal."
+                        )
+            return func(filename, signal, **kwargs)
+        return parse_argument
+    return decorator
+
 
 def dump_dictionary(
     file, dic, string="root", node_separator=".", value_separator=" = "
@@ -111,7 +130,7 @@ def overwrite(fname):
 
     Returns
     -------
-    bool : 
+    bool :
         Whether to overwrite file.
 
     """
@@ -223,5 +242,3 @@ def dict2sarray(dictionary, sarray=None, dtype=None):
         else:
             sarray[name] = dictionary[name]
     return sarray
-
-


### PR DESCRIPTION
Even `file_writer` are not explicitly part of the public API, I suspect that this may be used in the wild, so we should try to avoid this API, where possible. 
Using a decorator, this can be done easily for all writers.