### PR TITLE
mention RosettaSciIO in getting_started

### DIFF
--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -159,8 +159,8 @@ working with HyperSpy/Python interactively.
 Loading data
 ------------
 
-Once HyperSpy is running, to load from a supported file format (see
-:external+rsciio:ref:`supported-formats`) simply type:
+Once HyperSpy is running, to load from a :external+rsciio:ref:`file format
+supported by RosettaSciIO <supported-formats>`, simply type:
 
 .. code-block:: python
 


### PR DESCRIPTION
Just a minor change, explicitly naming the new package name already in getting_started.rst

Inspired by the discussion in https://github.com/hyperspy/hyperspy/pull/2975