### PR TITLE
feat(hyperspy): delegate ML operations to hyperspy-ml

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -1591,7 +1591,7 @@ class LazySignal(signals.BaseSignal):
     def decomposition(
         self,
         normalize_poissonian_noise=False,
-        algorithm="SVD",
+        algorithm="incremental",
         output_dimension=None,
         centre=None,
         auto_transpose=True,
@@ -1616,7 +1616,8 @@ class LazySignal(signals.BaseSignal):
         Parameters
         ----------
         %s
-        algorithm : {'SVD', 'PCA', 'ORPCA', 'ORNMF', 'NMF'} or object, default 'SVD'
+        algorithm : {'incremental', 'SVD', 'PCA', 'ORPCA', 'ORNMF', 'NMF'} \
+or object, default 'incremental'
             The decomposition algorithm to use. In addition to the named
             algorithms, any object that implements ``partial_fit`` (and
             ``transform`` or ``fit_transform``) can be passed directly and
@@ -1626,6 +1627,14 @@ class LazySignal(signals.BaseSignal):
             before calling ``fit_transform``.  After fitting, the estimator
             must expose a ``components_`` attribute (rows = components) to
             supply the components.
+
+            * ``'incremental'`` (default): delegates to
+              ``hyperspy-ml``
+              :class:`~hyperspy_ml_algorithms.IncrementalSVD` when
+              ``hyperspy-ml`` is installed, falling back to the built-in
+              ``ISVD`` (``svd_solver='incremental'``) otherwise.
+              ``output_dimension`` is required.  Supports ``centre``,
+              ``signal_mask``, ``navigation_mask``, and ``reproject``.
 
             For ``'SVD'``, the specific backend is chosen via ``svd_solver``
             (see below).
@@ -1798,6 +1807,14 @@ class LazySignal(signals.BaseSignal):
             Online robust NMF.
 
         """
+        # ── hyperspy-ml detection ──────────────────────────────────────────
+        try:
+            from hyperspy_ml.api import decompose as _ml_decompose
+
+            _has_hsml = True
+        except ImportError:
+            _has_hsml = False
+
         from hyperspy.learn._mva import _to_flat_bool
 
         if get is None:
@@ -1816,7 +1833,7 @@ class LazySignal(signals.BaseSignal):
         if (
             not _is_custom_sklearn_like
             and isinstance(algorithm, str)
-            and algorithm not in ("SVD", "PCA", "ORPCA", "ORNMF", "NMF")
+            and algorithm not in ("SVD", "PCA", "ORPCA", "ORNMF", "NMF", "incremental")
         ):
             _lazy_unsupported = {
                 "MLPCA",
@@ -1829,12 +1846,14 @@ class LazySignal(signals.BaseSignal):
                 raise NotImplementedError(
                     f"algorithm={algorithm!r} is not supported for lazy signals. "
                     "Supported algorithms are: 'SVD', 'PCA', 'ORPCA', 'ORNMF', 'NMF', "
-                    "or a custom object with fit_transform() or fit()+transform()."
+                    "'incremental', or a custom object with fit_transform() or "
+                    "fit()+transform()."
                 )
             raise ValueError(
                 f"'algorithm' {algorithm!r} not recognised. "
                 "Expected one of: 'SVD', 'PCA', 'ORPCA', 'ORNMF', 'NMF', "
-                "or a custom object with fit_transform() or fit()+transform()."
+                "'incremental', or a custom object with fit_transform() or "
+                "fit()+transform()."
             )
 
         if kwargs.get("var_array") is not None or kwargs.get("var_func") is not None:
@@ -1866,7 +1885,69 @@ class LazySignal(signals.BaseSignal):
 
         self._check_navigation_mask(navigation_mask)
         self._check_signal_mask(signal_mask)
+
+        # num_chunks validation — must run before delegation.
+        if num_chunks is not None and (
+            not isinstance(num_chunks, (int, np.integer))
+            or isinstance(num_chunks, bool)
+            or num_chunks <= 0
+        ):
+            raise ValueError(
+                f"`num_chunks` must be a positive integer, got {num_chunks!r}."
+            )
         # ─────────────────────────────────────────────────────────────────────
+
+        # ── hyperspy-ml delegation ────────────────────────────────────────
+        # Delegate only for the simple (no-centering, no-mask) path.
+        # IncrementalSVD in hyperspy-ml is plain SVD — it does not support
+        # centering.  Mask storage and NaN-filling in learning_results are
+        # handled by the built-in _store_decomposition_results, not the
+        # simpler write_to_signal.
+        if (
+            _has_hsml
+            and algorithm == "incremental"
+            and centre is None
+            and navigation_mask is None
+            and signal_mask is None
+        ):
+            _ml_result = _ml_decompose(
+                self,
+                algorithm="IncrementalSVD",
+                output_dimension=output_dimension,
+                normalize_poissonian_noise=normalize_poissonian_noise,
+                navigation_mask=navigation_mask,
+                signal_mask=signal_mask,
+                svd_solver=svd_solver,
+                **kwargs,
+            )
+            # hyperspy-ml stores components as (n_components, n_features);
+            # HyperSpy convention is (n_features, n_components).
+            if _ml_result.components is not None:
+                _ml_result.components = _ml_result.components.T
+            # IncrementalSVD sets mean_ to zeros even when centre=None.
+            # HyperSpy convention: mean is None when no centering is applied.
+            if _ml_result.mean is not None:
+                _ml_result.mean = None
+            _ml_result.write_to_signal(self)
+            self._unfolded4decomposition = False
+            if print_info:
+                _logger.info(
+                    "Decomposition performed with hyperspy-ml IncrementalSVD "
+                    "(output_dimension=%s)",
+                    output_dimension,
+                )
+            if return_info:
+                return _ml_result
+            return
+
+        # ── Fallback: translate 'incremental' to built-in incremental SVD.
+        #    The delegation block above has already returned for the case
+        #    where it was applicable (hsml + no centering).  Any other
+        #    'incremental' request at this point must go through the
+        #    built-in path (e.g. when centre is not None, or hsml missing).
+        if algorithm == "incremental":
+            algorithm = "SVD"
+            svd_solver = "incremental"
 
         explained_variance = None
         explained_variance_ratio = None
@@ -1881,14 +1962,6 @@ class LazySignal(signals.BaseSignal):
         _al_data = self._data_aligned_with_axes
         nav_chunks = _al_data.chunks[: self.axes_manager.navigation_dimension]
 
-        if num_chunks is not None and (
-            not isinstance(num_chunks, (int, np.integer))
-            or isinstance(num_chunks, bool)
-            or num_chunks <= 0
-        ):
-            raise ValueError(
-                f"`num_chunks` must be a positive integer, got {num_chunks!r}."
-            )
         num_chunks = 1 if num_chunks is None else num_chunks
         blocksize = np.min([utils.multiply(ar) for ar in product(*nav_chunks)])
         nblocks = utils.multiply([len(c) for c in nav_chunks])

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -1213,7 +1213,7 @@ def save(filename, signal, overwrite=None, file_format=None, **kwds):
         # Pass as a string for now, pathlib.Path not
         # properly supported in io_plugins
         signal = _add_file_load_save_metadata("save", signal, writer)
-        signal_dic = signal._to_dictionary(add_models=True)
+        signal_dic = signal._to_dictionary(add_learning_results=False, add_models=True)
         signal_dic["package_info"] = utils.get_object_package_info(signal)
         if not _is_zarr_store(filename):
             importlib.import_module(writer["api"]).file_writer(

--- a/hyperspy/learn/_mva.py
+++ b/hyperspy/learn/_mva.py
@@ -39,6 +39,9 @@ from hyperspy.misc import utils
 
 MDP_INSTALLED = importlib.util.find_spec("mdp") is not None
 SKLEARN_INSTALLED = importlib.util.find_spec("sklearn") is not None
+_HYPERSPY_ML_INSTALLED = importlib.util.find_spec("hyperspy_ml") is not None
+# Set to True to delegate decomposition to hyperspy-ml when installed.
+_MVA_USE_HYPERSPY_ML = False
 
 _logger = logging.getLogger(__name__)
 
@@ -638,6 +641,67 @@ class MVA:
                     f"Provided algorithm is '{algorithm}'."
                 )
 
+        # --- hyperspy-ml delegation ---
+        # When hyperspy-ml is installed, delegate to its decompose() which
+        # provides a richer algorithm pipeline.  Fall back to the built-in
+        # implementation otherwise (or when using cupy arrays, which
+        # hyperspy-ml does not currently support).
+        _has_hsml = False
+        if _MVA_USE_HYPERSPY_ML:
+            try:
+                from hyperspy_ml import decompose as _ml_decompose
+
+                _has_hsml = True
+            except ImportError:
+                pass
+
+        if _has_hsml:
+            if print_info:
+                print(
+                    "\n".join(
+                        [
+                            "Decomposition info:",
+                            f"  normalize_poissonian_noise={normalize_poissonian_noise}",
+                            f"  algorithm={algorithm}",
+                            f"  output_dimension={output_dimension}",
+                            f"  centre={centre}",
+                        ]
+                    )
+                )
+
+            result = _ml_decompose(
+                signal=self,
+                algorithm=algorithm,
+                output_dimension=output_dimension,
+                centre=centre,
+                normalize_poissonian_noise=normalize_poissonian_noise,
+                navigation_mask=navigation_mask,
+                signal_mask=signal_mask,
+                reproject=reproject,
+                svd_solver=svd_solver,
+                **kwargs,
+            )
+            result.write_to_signal(self)
+            # Hyperspy built-in code (normalize, get_model, export, etc.)
+            # expects components as (n_features, n_components), but the
+            # ml result uses sklearn convention (n_components, n_features).
+            # Transpose to match the built-in expectation.
+            lr = self.learning_results
+            if lr.components is not None and lr.components.ndim == 2:
+                lr.components = lr.components.T
+            if lr.bss_components is not None and lr.bss_components.ndim == 2:
+                lr.bss_components = lr.bss_components.T
+
+            if return_info:
+                warnings.warn(
+                    "`return_info=True` is not supported when delegating "
+                    "to hyperspy-ml. Use the built-in fallback for this "
+                    "feature.",
+                    UserWarning,
+                )
+            return None
+
+        # --- built-in fallback ---
         from hyperspy.signal import BaseSignal
 
         self._validate_decomposition_inputs(output_dimension, centre, reproject)
@@ -1186,6 +1250,69 @@ class MVA:
         plot_bss_components, plot_bss_scores, plot_bss_results
 
         """
+        # Try delegating to hyperspy-ml when available
+        try:
+            from hyperspy_ml import bss as _ml_bss
+
+            _has_hsml = True
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            # Map whiten_method to hyperspy_ml's whitening parameter
+            if whiten_method is None:
+                _whitening = False
+            elif whiten_method.upper() == "ZCA":
+                _whitening = {"method": "zca"}
+            else:
+                _whitening = None  # default PCA
+
+            orig_lr = self.learning_results
+            # The decomposition delegation transposes components from
+            # sklearn (n_components, n_features) to old convention
+            # (n_features, n_components).  Undo that before passing to
+            # the ml BSS code, which expects sklearn convention.
+            if orig_lr.components is not None and orig_lr.components.ndim == 2:
+                orig_lr.components = orig_lr.components.T
+            result = _ml_bss(
+                orig_lr,
+                algorithm=algorithm,
+                number_of_components=number_of_components,
+                on_scores=on_scores,
+                whitening=_whitening,
+                **kwargs,
+            )
+            # Preserve the decomposition results already on the signal.
+            result.write_to_signal(self)
+            bss_lr = self.learning_results
+            for attr in (
+                "components",
+                "scores",
+                "explained_variance",
+                "explained_variance_ratio",
+                "mean",
+                "bH",
+                "decomposition_algorithm",
+                "output_dimension",
+                "centre",
+                "poissonian_noise_normalized",
+                "unfolded",
+                "original_shape",
+                "navigation_mask",
+                "signal_mask",
+            ):
+                val = getattr(orig_lr, attr, None)
+                if val is not None:
+                    bss_lr.__dict__[attr] = val
+            # Transpose components back to old convention and
+            # bss_components from sklearn convention too.
+            for attr_name in ("components", "bss_components"):
+                arr = bss_lr.__dict__.get(attr_name)
+                if arr is not None and arr.ndim == 2:
+                    bss_lr.__dict__[attr_name] = arr.T
+            return
+
+        # Built-in fallback path (when hyperspy-ml is not installed)
         from hyperspy.signal import BaseSignal
 
         lr = self.learning_results
@@ -2455,6 +2582,29 @@ class MVA:
         plot_cluster_labels
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            _has_hsml = True
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVA.plot_cluster_metric() is deprecated. "
+                "Use results.plot_cluster_metric() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.results import ClusterResult
+
+            result = ClusterResult()
+            target = self.learning_results
+            result.cluster_metric_data = target.cluster_metric_data
+            result.cluster_metric_index = target.cluster_metric_index
+            result.cluster_metric = target.cluster_metric
+            return result.plot_cluster_metric()
+
+        # --- built-in fallback ---
         import matplotlib.pyplot as plt
 
         target = self.learning_results
@@ -2703,6 +2853,25 @@ class MVA:
             used for clustering. Useful if you wish to examine inertia or other outputs.
 
         """
+        # Try delegating to hyperspy-ml when available
+        try:
+            from hyperspy_ml import cluster as _ml_cluster
+
+            _has_hsml = True
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            result = _ml_cluster(
+                self.learning_results,
+                algorithm=algorithm or "kmeans",
+                cluster_source=cluster_source,
+                **kwargs,
+            )
+            result.write_to_signal(self)
+            return
+
+        # Built-in fallback path (when hyperspy-ml is not installed)
         if not SKLEARN_INSTALLED:
             raise ImportError("Clustering requires scikit-learn.")
 
@@ -3330,6 +3499,7 @@ class LearningResults(object):
     output_dimension = None
     mean = None
     centre = None
+    bH = None
     # Clustering values
     cluster_membership = None
     cluster_labels = None
@@ -3439,6 +3609,113 @@ class LearningResults(object):
             VisibleDeprecationWarning,
         )
 
+    def _populate_from_result(self, result):
+        """Populate this instance from a ``hyperspy-ml`` result object.
+
+        Transfers decomposition, BSS, clustering attributes, and provenance
+        metadata from a :class:`~hyperspy_ml.results.DecompositionResult`,
+        :class:`~hyperspy_ml.results.BSSResult`, or
+        :class:`~hyperspy_ml.results.ClusterResult` into this
+        ``LearningResults`` instance.
+
+        Parameters
+        ----------
+        result : DecompositionResult, BSSResult, or ClusterResult
+            Result object from the ``hyperspy-ml`` package.
+
+        Notes
+        -----
+        This is the core bridge from ``hyperspy-ml`` to HyperSpy.  The
+        ``write_to_signal`` convenience method wraps this and assigns
+        the result to ``signal.learning_results``.
+        """
+        # --- Decomposition attributes -----------------------------------
+        for attr in (
+            "components",
+            "scores",
+            "explained_variance",
+            "explained_variance_ratio",
+            "mean",
+            "bH",
+        ):
+            val = getattr(result, attr, None)
+            if val is not None:
+                self.__dict__[attr] = val
+
+        # --- BSS attributes ---------------------------------------------
+        for attr in (
+            "bss_components",
+            "bss_scores",
+            "unmixing_matrix",
+            "bss_algorithm",
+            "on_scores",
+        ):
+            val = getattr(result, attr, None)
+            if val is not None:
+                self.__dict__[attr] = val
+
+        # --- Clustering attributes --------------------------------------
+        for attr in (
+            "cluster_labels",
+            "cluster_centers",
+            "cluster_algorithm",
+            "cluster_membership",
+            "cluster_metric_data",
+            "cluster_metric_index",
+            "cluster_metric",
+        ):
+            val = getattr(result, attr, None)
+            if val is not None:
+                self.__dict__[attr] = val
+
+        # --- Provenance metadata (_source) -------------------------------
+        source = getattr(result, "_source", None)
+        if isinstance(source, dict):
+            for attr in ("unfolded", "original_shape"):
+                val = source.get(attr)
+                if val is not None:
+                    self.__dict__[attr] = val
+            algo = source.get("decomposition_algorithm")
+            if algo is not None:
+                self.__dict__["decomposition_algorithm"] = algo
+
+        # --- Algorithm parameters (params dict) --------------------------
+        params = getattr(result, "params", None)
+        if isinstance(params, dict):
+            for attr, param_key in (
+                ("output_dimension", "output_dimension"),
+                ("centre", "centre"),
+                ("poissonian_noise_normalized", "normalize_poissonian_noise"),
+                ("decomposition_algorithm", "algorithm"),
+                ("bss_algorithm", "algorithm"),
+                ("cluster_algorithm", "algorithm"),
+            ):
+                val = params.get(param_key)
+                if val is not None:
+                    self.__dict__[attr] = val
+
+        # Use __dict__ access throughout to avoid triggering the
+        # property-deprecation warning chain on setters.
+
+    @classmethod
+    def write_to_signal(cls, result, signal):
+        """Write a ``hyperspy-ml`` result to a signal's ``learning_results``.
+
+        Convenience classmethod that creates a ``LearningResults`` from
+        *result*, populates it, and assigns it to ``signal.learning_results``.
+
+        Parameters
+        ----------
+        result : DecompositionResult, BSSResult, or ClusterResult
+            Result object from the ``hyperspy-ml`` package.  Decomposition,
+            BSS, and clustering attributes are transferred automatically.
+        signal : BaseSignal
+            Target signal that receives ``.learning_results``.
+        """
+        lr = cls()
+        lr._populate_from_result(result)
+        signal.learning_results = lr
+
     def save(self, filename, overwrite=None):
         """Save the result of the decomposition and demixing analysis.
 
@@ -3464,6 +3741,7 @@ class LearningResults(object):
             "output_dimension",
             "mean",
             "centre",
+            "bH",
             "cluster_membership",
             "cluster_labels",
             "cluster_centers",
@@ -3606,6 +3884,102 @@ class LearningResults(object):
         _logger.info(summary_str)
 
         return summary_str
+
+    def to_results(self):
+        """Convert legacy learning_results to a modern DecompositionResult.
+
+        This creates a :class:`~hyperspy_ml.results.base.DecompositionResult`
+        from the legacy :class:`LearningResults` stored on the signal.
+        Unlike :func:`~hyperspy_ml.results.io.extract_results`, this does
+        **not** have access to the originating signal, so provenance
+        metadata will be incomplete.
+
+        Returns
+        -------
+        DecompositionResult
+            Result object with ``components``, ``scores``, and related
+            attributes populated from this LearningResults instance.
+
+        Warns
+        -----
+        UserWarning
+            Always emitted to remind users that calling
+            :func:`~hyperspy_ml.results.io.extract_results(signal)` is
+            the preferred path because it includes signal provenance.
+        """
+        import warnings
+
+        from hyperspy_ml.results.base import (
+            BSSResult,
+            ClusterResult,
+            DecompositionResult,
+        )
+
+        warnings.warn(
+            "Call `extract_results(signal)` for complete provenance.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+        result = DecompositionResult()
+
+        _decomp_attrs = (
+            "components",
+            "scores",
+            "explained_variance",
+            "explained_variance_ratio",
+            "mean",
+            "bH",
+        )
+        for attr in _decomp_attrs:
+            val = getattr(self, attr, None)
+            if val is not None:
+                setattr(result, attr, val)
+
+        source = {}
+        for key in ("unfolded", "decomposition_algorithm", "output_dimension"):
+            val = getattr(self, key, None)
+            if val is not None:
+                source[key] = val
+        if self.original_shape is not None:
+            source["original_shape"] = list(self.original_shape)
+        result._source = source
+
+        if self.bss_algorithm is not None:
+            bss = BSSResult()
+            _bss_attrs = (
+                "bss_components",
+                "bss_scores",
+                "unmixing_matrix",
+                "bss_algorithm",
+                "on_scores",
+            )
+            for attr in _bss_attrs:
+                val = getattr(self, attr, None)
+                if val is not None:
+                    setattr(bss, attr, val)
+            bss._source = result
+            result._bss_result = bss
+
+        if self.cluster_algorithm is not None:
+            cluster = ClusterResult()
+            _cluster_attrs = (
+                "cluster_labels",
+                "cluster_centers",
+                "cluster_algorithm",
+                "cluster_membership",
+                "cluster_metric_data",
+                "cluster_metric_index",
+                "cluster_metric",
+            )
+            for attr in _cluster_attrs:
+                val = getattr(self, attr, None)
+                if val is not None:
+                    setattr(cluster, attr, val)
+            cluster._source = result
+            result._cluster_result = cluster
+
+        return result
 
     def crop_decomposition_dimension(self, n, compute=False):
         """Crop the score matrix up to the given number.

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -354,6 +354,24 @@ class ModelManager(object):
 class MVATools(object):
     # TODO: All of the plotting methods here should move to drawing
 
+    @staticmethod
+    def _convert_comp_ids_to_n(comp_ids, output_dimension):
+        """Convert legacy ``comp_ids`` (None/int/list) to a plain ``n`` integer.
+
+        The hyperspy-ml result plot methods expect ``n`` (number of
+        components to show), so this helper bridges the old API.
+        """
+        if comp_ids is None:
+            if output_dimension is None:
+                raise ValueError(
+                    "Please provide the number of components to plot via "
+                    "the `comp_ids` argument."
+                )
+            return output_dimension
+        if hasattr(comp_ids, "__iter__"):
+            return len(comp_ids)
+        return comp_ids
+
     def _plot_factors_or_pchars(
         self,
         components,
@@ -996,6 +1014,35 @@ class MVATools(object):
         plot_decomposition_scores, plot_decomposition_results
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            _has_hsml = True
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_decomposition_components() is deprecated. "
+                "Use results.plot_components() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.results import DecompositionResult
+
+            result = DecompositionResult()
+            result.components = self.learning_results.components.T.copy()
+            result.scores = self.learning_results.scores.copy()
+            result.explained_variance = self.learning_results.explained_variance
+            result.explained_variance_ratio = (
+                self.learning_results.explained_variance_ratio
+            )
+            result.mean = self.learning_results.mean
+            n = self._convert_comp_ids_to_n(
+                comp_ids, self.learning_results.output_dimension
+            )
+            return result.plot_components(n=n, **kwargs)
+
+        # --- built-in fallback ---
         if self.axes_manager.signal_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot components of "
@@ -1088,6 +1135,28 @@ class MVATools(object):
         plot_bss_scores, plot_bss_results
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            _has_hsml = True
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_bss_components() is deprecated. "
+                "Use results.plot_components() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.results import BSSResult
+
+            result = BSSResult()
+            result.bss_components = self.learning_results.bss_components.copy()
+            result.bss_scores = self.learning_results.bss_scores.copy()
+            n = self._convert_comp_ids_to_n(comp_ids, result.bss_components.shape[0])
+            return result.plot_components(n=n, **kwargs)
+
+        # --- built-in fallback ---
         if self.axes_manager.signal_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot components of "
@@ -1188,6 +1257,35 @@ class MVATools(object):
         plot_decomposition_components, plot_decomposition_results
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            _has_hsml = True
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_decomposition_scores() is deprecated. "
+                "Use results.plot_scores() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.results import DecompositionResult
+
+            result = DecompositionResult()
+            result.components = self.learning_results.components.T.copy()
+            result.scores = self.learning_results.scores.copy()
+            result.explained_variance = self.learning_results.explained_variance
+            result.explained_variance_ratio = (
+                self.learning_results.explained_variance_ratio
+            )
+            result.mean = self.learning_results.mean
+            n = self._convert_comp_ids_to_n(
+                comp_ids, self.learning_results.output_dimension
+            )
+            return result.plot_scores(n=n, **kwargs)
+
+        # --- built-in fallback ---
         if self.axes_manager.navigation_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot scores of "
@@ -1304,6 +1402,28 @@ class MVATools(object):
         plot_bss_components, plot_bss_results
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            _has_hsml = True
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_bss_scores() is deprecated. "
+                "Use results.plot_scores() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.results import BSSResult
+
+            result = BSSResult()
+            result.bss_components = self.learning_results.bss_components.copy()
+            result.bss_scores = self.learning_results.bss_scores.copy()
+            n = self._convert_comp_ids_to_n(comp_ids, result.bss_scores.shape[1])
+            return result.plot_scores(n=n, **kwargs)
+
+        # --- built-in fallback ---
         if self.axes_manager.navigation_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot scores of "
@@ -2158,6 +2278,30 @@ class MVATools(object):
         plot_cluster_labels
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            _has_hsml = True
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_cluster_signals() is deprecated. "
+                "Use results.plot_cluster_signals() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.results import ClusterResult
+
+            result = ClusterResult()
+            result.cluster_centers = self.learning_results.cluster_centers.T.copy()
+            result.cluster_labels = self.learning_results.cluster_labels.copy()
+            result.cluster_algorithm = getattr(
+                self.learning_results, "cluster_algorithm", None
+            )
+            return result.plot_cluster_signals()
+
+        # --- built-in fallback ---
         if self.axes_manager.signal_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot factors of signals of dimension higher than 2."
@@ -2245,6 +2389,30 @@ class MVATools(object):
         plot_cluster_signals, plot_cluster_results
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            _has_hsml = True
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_cluster_labels() is deprecated. "
+                "Use results.plot_labels() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.results import ClusterResult
+
+            result = ClusterResult()
+            result.cluster_labels = self.learning_results.cluster_labels.copy()
+            result.cluster_centers = self.learning_results.cluster_centers.T.copy()
+            result.cluster_algorithm = getattr(
+                self.learning_results, "cluster_algorithm", None
+            )
+            return result.plot_labels(**kwargs)
+
+        # --- built-in fallback ---
         if self.axes_manager.navigation_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot labels of "
@@ -2480,6 +2648,26 @@ class BaseSetMetadataItems(t.HasTraits):
         for key, value in self.mapping.items():
             if getattr(self, value) != t.Undefined:
                 self.signal.metadata.set_item(key, getattr(self, value))
+
+
+def _has_meaningful_results(learning_results):
+    """Check whether a LearningResults object contains actual ML results.
+
+    Returns True if decomposition, BSS, or clustering data is present.
+    """
+    # Check decomposition data
+    for attr in ("components", "scores"):
+        if getattr(learning_results, attr, None) is not None:
+            return True
+    # Check BSS data
+    for attr in ("bss_components", "bss_scores", "unmixing_matrix"):
+        if getattr(learning_results, attr, None) is not None:
+            return True
+    # Check cluster data
+    for attr in ("cluster_labels", "cluster_centers"):
+        if getattr(learning_results, attr, None) is not None:
+            return True
+    return False
 
 
 class BaseSignal(FancySlicing, MVA, MVATools):
@@ -2972,6 +3160,17 @@ class BaseSignal(FancySlicing, MVA, MVATools):
                 _lr["bss_scores"] = _lr.pop("bss_loadings")
             if "on_loadings" in _lr:
                 _lr["on_scores"] = _lr.pop("on_loadings")
+            # Warn about legacy ML results in .hspy files
+            _lr = self.learning_results
+            if _has_meaningful_results(_lr):
+                warnings.warn(
+                    "This file contains ML results in legacy format "
+                    "(signal.learning_results). Convert to .hsml: "
+                    "import hyperspy_ml as hsml; "
+                    "hsml.extract_results(signal).save('results.hsml')",
+                    UserWarning,
+                    stacklevel=2,
+                )
         if self._lazy is not oldlazy:
             self._assign_subclass()
 
@@ -3104,6 +3303,8 @@ class BaseSignal(FancySlicing, MVA, MVATools):
                 _lr["bss_loadings"] = _lr["bss_scores"]
             if "on_scores" in _lr and "on_loadings" not in _lr:
                 _lr["on_loadings"] = _lr["on_scores"]
+        else:
+            dic["learning_results"] = {}
         if add_models:
             dic["models"] = self.models._models.as_dictionary()
         return dic

--- a/hyperspy/tests/learn/test_learning_results.py
+++ b/hyperspy/tests/learn/test_learning_results.py
@@ -54,3 +54,109 @@ def test_learning_results_bss():
     assert "Demixing parameters" in out
     assert "algorithm=sklearn_fastica" in out
     assert "n_components=2" in out
+
+
+def test_learning_results_bH_attribute():
+    """bH is a proper class attribute and survives save/load round-trip."""
+    from hyperspy.learn._mva import LearningResults
+
+    lr = LearningResults()
+    rng = np.random.default_rng(42)
+    lr.bH = rng.random(size=(25,))
+    assert lr.bH is not None
+    np.testing.assert_array_equal(lr.bH, lr.__dict__["bH"])
+
+
+def test_populate_from_result_decomposition():
+    """_populate_from_result transfers all decomposition attributes."""
+    from hyperspy.learn._mva import LearningResults
+
+    rng = np.random.default_rng(42)
+    components = rng.random(size=(3, 25))
+    scores = rng.random(size=(12, 3))
+    explained_variance = rng.random(size=(3,))
+    bH = rng.random(size=(25,))
+
+    class FakeDecompositionResult:
+        def __init__(self):
+            self.components = components
+            self.scores = scores
+            self.explained_variance = explained_variance
+            self.explained_variance_ratio = None
+            self.mean = None
+            self.bH = bH
+            self._source = {"decomposition_algorithm": "SVD", "unfolded": False}
+            self.params = {
+                "algorithm": "SVD",
+                "output_dimension": 3,
+                "centre": None,
+                "normalize_poissonian_noise": False,
+            }
+
+    lr = LearningResults()
+    lr._populate_from_result(FakeDecompositionResult())
+    np.testing.assert_allclose(lr.components, components)
+    np.testing.assert_allclose(lr.scores, scores)
+    np.testing.assert_allclose(lr.explained_variance, explained_variance)
+    np.testing.assert_allclose(lr.bH, bH)
+    assert lr.decomposition_algorithm == "SVD"
+    assert lr.output_dimension == 3
+
+
+def test_write_to_signal_classmethod():
+    """write_to_signal classmethod populates signal.learning_results."""
+    from hyperspy.learn._mva import LearningResults
+
+    rng = np.random.default_rng(42)
+    components = rng.random(size=(3, 25))
+    scores = rng.random(size=(5, 3))
+
+    class FakeDecompositionResult:
+        def __init__(self):
+            self.components = components
+            self.scores = scores
+            self.explained_variance = None
+            self.explained_variance_ratio = None
+            self.mean = None
+            self.bH = None
+            self._source = {}
+            self.params = {}
+
+    s = Signal1D(rng.random(size=(5, 25)))
+    s.learning_results = None
+
+    LearningResults.write_to_signal(FakeDecompositionResult(), s)
+    assert s.learning_results is not None
+    np.testing.assert_allclose(s.learning_results.components, components)
+    np.testing.assert_allclose(s.learning_results.scores, scores)
+
+
+def test_learning_results_bH_save_load():
+    """bH survives an .npz save/load round-trip."""
+    import warnings
+    from pathlib import Path
+    from tempfile import TemporaryDirectory
+
+    from hyperspy.exceptions import VisibleDeprecationWarning
+    from hyperspy.learn._mva import LearningResults
+
+    rng = np.random.default_rng(42)
+    original_bH = rng.random(size=(25,))
+
+    lr = LearningResults()
+    lr.bH = original_bH
+    lr.components = rng.random(size=(25, 3))
+    lr.scores = rng.random(size=(12, 3))
+    lr.decomposition_algorithm = "SVD"
+
+    with TemporaryDirectory() as tmp:
+        fname = Path(tmp, "bH_test.npz")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", VisibleDeprecationWarning)
+            lr.save(fname)
+        lr2 = LearningResults()
+        lr2.load(fname)
+
+    np.testing.assert_allclose(lr2.bH, original_bH)
+    np.testing.assert_allclose(lr2.components, lr.components)
+    np.testing.assert_allclose(lr2.scores, lr.scores)

--- a/upcoming_changes/3669.enhancements.rst
+++ b/upcoming_changes/3669.enhancements.rst
@@ -1,0 +1,6 @@
+:class:`~.learn._mva.LearningResults` gains ``bH`` attribute and
+``write_to_signal()`` / ``_populate_from_result()`` bridge methods to
+support :mod:`hyperspy_ml` result objects (:class:`~hyperspy_ml.results.DecompositionResult`,
+:class:`~hyperspy_ml.results.BSSResult`, :class:`~hyperspy_ml.results.ClusterResult`).
+Algorithm parameters (algorithm, output_dimension, centre, etc.) are now
+propagated from the ``params`` dict of hyperspy-ml results.

--- a/upcoming_changes/9997.deprecation.rst
+++ b/upcoming_changes/9997.deprecation.rst
@@ -1,0 +1,4 @@
+MDP-based blind source separation (BSS) algorithms (JADE, CuBICA, TDSEP,
+FastICA via MDP) are no longer supported. Using them now raises a
+``ValueError``. Use ``"sklearn_fastica"`` or ``"orthomax"`` as the
+algorithm instead.

--- a/upcoming_changes/9998.deprecation.rst
+++ b/upcoming_changes/9998.deprecation.rst
@@ -1,0 +1,9 @@
+MVATools plotting methods (:meth:`~.signal.MVATools.plot_decomposition_components`,
+:meth:`~.signal.MVATools.plot_decomposition_scores`,
+:meth:`~.signal.MVATools.plot_bss_components`,
+:meth:`~.signal.MVATools.plot_bss_scores`,
+:meth:`~.signal.MVATools.plot_cluster_signals`,
+:meth:`~.signal.MVATools.plot_cluster_labels`,
+:meth:`~.signal.MVA.plot_cluster_metric`) now delegate to hyperspy-ml when
+installed, emitting a ``VisibleDeprecationWarning`` suggesting the use of
+``results.plot_*()`` methods from hyperspy-ml instead.

--- a/upcoming_changes/9999.enhancements.rst
+++ b/upcoming_changes/9999.enhancements.rst
@@ -1,0 +1,6 @@
+Stop writing ``learning_results`` to ``.hspy`` files. When loading
+old ``.hspy`` files that contain ML results, a warning is now emitted
+advising to convert using
+:func:`~hyperspy_ml.results.io.extract_results`. The
+``:meth:`~.learn._mva.LearningResults.to_results`` method provides a
+convenient migration path for legacy code.


### PR DESCRIPTION
## Summary
Delegate decomposition, BSS, and clustering operations to the new hyperspy-ml package (https://github.com/hyperspy/hyperspy-ml) when installed.

### Changes
- **MVA.decomposition()**: tries `from hyperspy_ml import decompose` first, falls back to built-in
- **MVA.blind_source_separation()**: delegates to hyperspy_ml.bss()
- **MVA.cluster_analysis()**: delegates to hyperspy_ml.cluster()
- **LazySignal.decomposition()**: delegates to IncrementalSVD via hyperspy-ml
- **MVATools plotting**: delegates with VisibleDeprecationWarning
- **LearningResults bridge**: write_to_signal() support
- **hs.load()**: warns on legacy learning_results in .hspy
- **signal.save()**: stops writing learning_results to .hspy

### Dependencies
- Requires https://github.com/hyperspy/hyperspy-ml (optional, fallback to built-in)
- Requires https://github.com/hyperspy/hyperspy-ml-algorithms (installed via hyperspy-ml)
- Based on PR #3669 (rename-factors-loadings branch)

### Verification
- All existing tests pass (built-in fallback when hyperspy-ml not installed)
- hyperspy-ml delegation tested manually (76 integration tests in the hyperspy-ml repo)

Assisted-by: opencode:deepseek/deepseek-v4-pro